### PR TITLE
Refactored the Noark 5.3 package structure model

### DIFF
--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/properties/Noark53Properties.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/properties/Noark53Properties.java
@@ -29,8 +29,6 @@ import org.apache.commons.configuration.ConfigurationException;
 
 public class Noark53Properties extends InternalProperties {
 
-	private Noark5PackageStructure packageStructure = new Noark5PackageStructure();
-
 	private Map<String, Set<String>> uniqueFieldsMap = new HashMap<>();
 
 	private Map<String, Set<String>> extraFieldsMap = new HashMap<>();
@@ -44,14 +42,6 @@ public class Noark53Properties extends InternalProperties {
 		setUniqueFieldsPerTable();
 		setExtraFieldsPerTable();
 		setChecksums();
-	}
-
-	/**
-	 * Retrieves the Noark 5 package structure.
-	 */
-	public Noark5PackageStructure getPackageStructure() {
-
-		return packageStructure;
 	}
 
 	/**
@@ -162,59 +152,5 @@ public class Noark53Properties extends InternalProperties {
 		}
 
 		return map;
-	}
-
-	public static class Noark5PackageStructure {
-
-		private Map<String, Set<String>> structure;
-
-		Noark5PackageStructure() {
-
-			init();
-		}
-
-		public Set<String> getXSDSchemasFor(String xmlFileName) {
-
-			return structure.get(xmlFileName);
-		}
-
-		public Set<String> getAllXMLFiles() {
-
-			return structure.keySet();
-		}
-
-		public Set<String> getAllXSDFiles() {
-
-			Set<String> xsdSchemas = new HashSet<>();
-
-			for (String xmlFile : getAllXMLFiles()) {
-				xsdSchemas.addAll(getXSDSchemasFor(xmlFile));
-			}
-
-			return xsdSchemas;
-		}
-
-		/**
-		 * < xml file name , set of associated XSD schemas file names >
-		 */
-		public Map<String, Set<String>> getPackageStructure() {
-
-			return Collections.unmodifiableMap(structure);
-		}
-
-		private void init() {
-
-			structure = new HashMap<>();
-
-			Set<String> archiveStructureXSDs = new HashSet<>();
-			archiveStructureXSDs.add("arkivstruktur.xsd");
-			archiveStructureXSDs.add("metadatakatalog.xsd");
-
-			structure.put("arkivstruktur.xml", Collections.unmodifiableSet(archiveStructureXSDs));
-			structure.put("arkivuttrekk.xml", Collections.singleton("addml.xsd"));
-			structure.put("endringslogg.xml", Collections.singleton("endringslogg.xsd"));
-			structure.put("loependeJournal.xml", Collections.singleton("loependeJournal.xsd"));
-			structure.put("offentligJournal.xml", Collections.singleton("offentligJournal.xsd"));
-		}
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
@@ -20,13 +20,12 @@ package com.documaster.validator.validation.noark53;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
@@ -51,6 +50,8 @@ import com.documaster.validator.validation.noark53.provider.ValidationData;
 import com.documaster.validator.validation.noark53.provider.ValidationGroup;
 import com.documaster.validator.validation.noark53.provider.ValidationProvider;
 import com.documaster.validator.validation.noark53.provider.ValidationRule;
+import com.documaster.validator.validation.noark53.model.Noark53PackageEntity;
+import com.documaster.validator.validation.noark53.model.Noark53PackageStructure;
 import com.documaster.validator.validation.noark53.validators.XMLValidator;
 import com.documaster.validator.validation.noark53.validators.XSDValidator;
 import com.documaster.validator.validation.utils.ChecksumCalculator;
@@ -67,7 +68,7 @@ public class Noark53Validator extends Validator<Noark53Command> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Noark53Validator.class);
 
-	private Map<String, File> tempXsdSchemas;
+	private Noark53PackageStructure structure;
 
 	private XsdConverter converter;
 
@@ -82,9 +83,8 @@ public class Noark53Validator extends Validator<Noark53Command> {
 		LOGGER.info("Executing Noark 5.3 extraction validation ...");
 
 		try {
-			// Validate the extraction package structure
-			createTempSchemas();
-			validateArchiveStructure();
+			prepareStructure();
+			validateStructure();
 
 			// Init storage
 			Storage.init(getCommand().getStorageDelegate(), getCommand().getProperties().getUniqueFieldsMap());
@@ -118,67 +118,64 @@ public class Noark53Validator extends Validator<Noark53Command> {
 
 		} finally {
 
+			FileUtils.deleteQuietly(structure.getNoarkSchemasDirectory());
+
 			ReporterFactory.createReporter(getCommand().getReporterDelegate(), getArchiveTitle()).createReport();
 
 			if (Storage.get() != null) {
 				Storage.get().stopWriter();
 				Storage.get().destroy();
 			}
-
-			cleanUpTempSchemas();
 		}
 	}
 
 	/**
-	 * Creates temporary files from the archive schemas distributed with the tool.
+	 * Prepares the {@link Noark53PackageStructure}.
 	 */
-	private void createTempSchemas() throws Exception {
+	private void prepareStructure() throws IOException {
 
-		tempXsdSchemas = new HashMap<>();
+		// Temporary directory for storing the original Noark 5.3 schemas
+		File tempNoarkSchemasDirectory = Files.createTempDirectory("noark-extraction-validator-").toFile();
 
-		for (String xsdFileName : getCommand().getProperties().getPackageStructure().getAllXSDFiles()) {
+		// Initialize the package structure
+		structure = new Noark53PackageStructure(getCommand().getExtractionDirectory(), tempNoarkSchemasDirectory);
 
-			String xsdFileLocation = Noark53Command.COMMAND_NAME + "/" + xsdFileName;
+		// Create temporary files containing the original Noark 5.3 schemas
+		for (Noark53PackageEntity entity : structure.values()) {
 
-			String tempDir = System.getProperty("java.io.tmpdir");
+			for (String xsdSchemaName : entity.getXsdShemasNames()) {
 
-			File tempXsdFile = new File(tempDir, xsdFileName);
+				String noarkSchemaLocation = Noark53Command.COMMAND_NAME + "/" + xsdSchemaName;
+				File tempXsdFile = new File(tempNoarkSchemasDirectory, xsdSchemaName);
 
-			FileUtils.copyInputStreamToFile(
-					getClass().getClassLoader().getResourceAsStream(xsdFileLocation),
-					tempXsdFile);
-
-			tempXsdSchemas.put(xsdFileName, tempXsdFile);
+				FileUtils.copyInputStreamToFile(
+						getClass().getClassLoader().getResourceAsStream(noarkSchemaLocation),
+						tempXsdFile);
+			}
 		}
 	}
 
 	/**
-	 * Validates the integrity of the archive structure.
+	 * Validates the integrity of the extraction package structure.
 	 */
-	private void validateArchiveStructure() throws Exception {
-
-		// Validate the schemas in the extraction package
-		for (String xsdSchemaName : getCommand().getProperties().getPackageStructure().getAllXSDFiles()) {
-			File xsdSchema = new File(getCommand().getExtractionDirectory(), xsdSchemaName);
-			XSDValidator.validate(xsdSchema, getCommand().getProperties().getChecksumFor(xsdSchemaName));
-		}
+	private void validateStructure() throws Exception {
 
 		boolean stopValidation = false;
 
-		// Validate the XML files in the package against the bundled XSD schemas
-		for (String xmlFileName : getCommand().getProperties().getPackageStructure().getAllXMLFiles()) {
+		for (Noark53PackageEntity entity : structure.values()) {
 
-			File xmlFile = new File(getCommand().getExtractionDirectory(), xmlFileName);
-			Set<String> xsdSchemaNames = getCommand().getProperties().getPackageStructure()
-					.getXSDSchemasFor(xmlFileName);
-
-			List<File> xsdSchemaFiles = new ArrayList<>();
-			for (String xsdSchemaName : xsdSchemaNames) {
-				xsdSchemaFiles.add(tempXsdSchemas.get(xsdSchemaName));
+			if (!entity.getXmlFile().isFile() && entity.isOptional()) {
+				LOGGER.info("Did not validate missing optional XML entity {}", entity.getXmlFileName());
+				continue;
 			}
 
-			boolean isXMLValid = XMLValidator
-					.validate(xmlFile, xsdSchemaFiles, getCommand().getIgnoreNonCompliantXML());
+			// Validate the extraction-distributed XSD schemas
+			for (File xsdSchema : entity.getPackageSchemas()) {
+				XSDValidator.validate(xsdSchema, getCommand().getProperties().getChecksumFor(xsdSchema.getName()));
+			}
+
+			// Validate the extraction-distributed XML files
+			boolean isXMLValid = XMLValidator.validate(entity, getCommand().getIgnoreNonCompliantXML());
 			stopValidation = stopValidation || !isXMLValid;
 		}
 
@@ -194,7 +191,7 @@ public class Noark53Validator extends Validator<Noark53Command> {
 	private void convertXSDSchemas() throws Exception {
 
 		converter = new XsdConverter();
-		converter.convert(new ArrayList<>(tempXsdSchemas.values()));
+		converter.convert(structure.getAllNoarkSchemaFiles());
 
 		// Add additional fields
 		for (ItemDef itemDef : converter.getItemDefs().values()) {
@@ -239,9 +236,12 @@ public class Noark53Validator extends Validator<Noark53Command> {
 
 		LOGGER.info("Storing XML data and extracting document information ...");
 
-		for (String xmlFilename : getCommand().getProperties().getPackageStructure().getAllXMLFiles()) {
+		for (Noark53PackageEntity entity : structure.values()) {
 
-			File xmlFile = new File(getCommand().getExtractionDirectory(), xmlFilename);
+			if (!entity.getXmlFile().isFile() && entity.isOptional()) {
+				LOGGER.info("Did not persist missing optional XML entity {}", entity.getXmlFileName());
+				continue;
+			}
 
 			ValidationErrorHandler errorHandler = new ValidationErrorHandler();
 			SAXParserFactory spf = SAXParserFactory.newInstance();
@@ -249,13 +249,13 @@ public class Noark53Validator extends Validator<Noark53Command> {
 
 			XMLReader reader = saxParser.getXMLReader();
 
-			BaseHandler xmlHandler = HandlerFactory.createHandler(xmlFile, reader, converter.getItemDefs());
+			BaseHandler xmlHandler = HandlerFactory.createHandler(entity.getXmlFile(), reader, converter.getItemDefs());
 
 			reader.setContentHandler(xmlHandler);
 			reader.setErrorHandler(errorHandler);
 
 			try (
-					FileInputStream fis = new FileInputStream(xmlFile);
+					FileInputStream fis = new FileInputStream(entity.getXmlFile());
 					BufferedInputStream bis = new BufferedInputStream(fis)) {
 				reader.parse(new InputSource(bis));
 			}
@@ -269,34 +269,32 @@ public class Noark53Validator extends Validator<Noark53Command> {
 	}
 
 	/**
-	 * Retrieves the checksums of all documents in the extraction package and stores them in the addml.property {@link
+	 * Retrieves the checksums of all entities in the extraction package and stores them in the addml.property {@link
 	 * ItemDef}.
 	 */
 	private void storePackageChecksums() throws Exception {
 
-		// Store the checksums of all XSD files
-		for (String xsdSchemaName : getCommand().getProperties().getPackageStructure().getAllXSDFiles()) {
+		for (Noark53PackageEntity entity : structure.values()) {
 
-			File xsdSchema = new File(getCommand().getExtractionDirectory(), xsdSchemaName);
+			if (!entity.getXmlFile().isFile() && entity.isOptional()) {
+				LOGGER.info("Did not retrieve the checksum of missing optional XML entity {}", entity.getXmlFileName());
+			}
 
-			Item xsdSchemaChecksumItem = new Item(converter.getItemDefs().get("addml.property"));
-			xsdSchemaChecksumItem.add("name", xsdSchemaName);
-			xsdSchemaChecksumItem.add("value", ChecksumCalculator.getFileSha256Checksum(xsdSchema));
+			storePackageEntityChecksum(entity.getXmlFile());
 
-			Storage.get().write(xsdSchemaChecksumItem);
+			for (File schema : entity.getPackageSchemas()) {
+				storePackageEntityChecksum(schema);
+			}
 		}
+	}
 
-		// Store the checksums of all XML files
-		for (String xmlFileName : getCommand().getProperties().getPackageStructure().getAllXMLFiles()) {
+	private void storePackageEntityChecksum(File file) {
 
-			File xmlFile = new File(getCommand().getExtractionDirectory(), xmlFileName);
+		Item itemChecksum = new Item(converter.getItemDefs().get("addml.property"));
+		itemChecksum.add("name", file.getName());
+		itemChecksum.add("value", ChecksumCalculator.getFileSha256Checksum(file));
 
-			Item xmlFileChecksumItem = new Item(converter.getItemDefs().get("addml.property"));
-			xmlFileChecksumItem.add("name", xmlFileName);
-			xmlFileChecksumItem.add("value", ChecksumCalculator.getFileSha256Checksum(xmlFile));
-
-			Storage.get().write(xmlFileChecksumItem);
-		}
+		Storage.get().write(itemChecksum);
 	}
 
 	private void runValidationQueries() throws Exception {
@@ -354,14 +352,5 @@ public class Noark53Validator extends Validator<Noark53Command> {
 		}
 
 		return archiveTitle;
-	}
-
-	private void cleanUpTempSchemas() {
-
-		if (tempXsdSchemas != null) {
-			for (File xsdSchema : tempXsdSchemas.values()) {
-				FileUtils.deleteQuietly(xsdSchema);
-			}
-		}
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageEntity.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageEntity.java
@@ -1,0 +1,100 @@
+/**
+ * Noark Extraction Validator
+ * Copyright (C) 2017, Documaster AS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.documaster.validator.validation.noark53.model;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang.Validate;
+
+/**
+ * Represents a construct of the {@link Noark53PackageStructure}, i.e. an XML file and its corresponding XSD schemas.
+ */
+public class Noark53PackageEntity {
+
+	private final Noark53PackageStructure structure;
+	private final String xmlFileName;
+	private final boolean optional;
+	private final Set<String> xsdSchemasNames;
+
+	Noark53PackageEntity(
+			Noark53PackageStructure structure, String xmlFileName, boolean optional, String... schemaNames) {
+
+		Validate.notEmpty(xmlFileName);
+
+		this.structure = structure;
+		this.xmlFileName = xmlFileName;
+		this.optional = optional;
+
+		Set<String> schemaNamesSet = new HashSet<>();
+		Collections.addAll(schemaNamesSet, schemaNames);
+		xsdSchemasNames = Collections.unmodifiableSet(schemaNamesSet);
+	}
+
+	public String getXmlFileName() {
+
+		return xmlFileName;
+	}
+
+	public boolean isOptional() {
+
+		return optional;
+	}
+
+	public Set<String> getXsdShemasNames() {
+
+		return xsdSchemasNames;
+	}
+
+	public File getXmlFile() {
+
+		return new File(structure.getExtractionDirectory(), xmlFileName);
+	}
+
+	/**
+	 * Retrieves the related XSD schema files distributed with the extraction package.
+	 */
+	public List<File> getPackageSchemas() {
+
+		List<File> packageSchemas = new ArrayList<>();
+
+		for (String xsdSchemaName : xsdSchemasNames) {
+			packageSchemas.add(new File(structure.getExtractionDirectory(), xsdSchemaName));
+		}
+
+		return Collections.unmodifiableList(packageSchemas);
+	}
+
+	/**
+	 * Retrieves the Noark 5.3 XSD schema files.
+	 */
+	public List<File> getNoarkSchemas() {
+
+		List<File> noarkSchemas = new ArrayList<>();
+
+		for (String xsdSchemaName : xsdSchemasNames) {
+			noarkSchemas.add(new File(structure.getNoarkSchemasDirectory(), xsdSchemaName));
+		}
+
+		return Collections.unmodifiableList(noarkSchemas);
+	}
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageStructure.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageStructure.java
@@ -1,0 +1,83 @@
+/**
+ * Noark Extraction Validator
+ * Copyright (C) 2017, Documaster AS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.documaster.validator.validation.noark53.model;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang.Validate;
+
+/**
+ * The Noark 5.3 extraction package structure represented as a {@link HashMap} implementation.
+ * <p/>
+ * <b>keys: </b> XML file names<br/>
+ * <b>values: </b> {@link Noark53PackageEntity}
+ */
+public class Noark53PackageStructure extends HashMap<String, Noark53PackageEntity> {
+
+	private File extractionDirectory;
+	private File noarkSchemasDirectory;
+
+	public Noark53PackageStructure(File extractionDirectory, File noarkSchemasDirectory) {
+
+		Validate.isTrue(extractionDirectory.isDirectory());
+		Validate.isTrue(noarkSchemasDirectory.isDirectory());
+
+		this.extractionDirectory = extractionDirectory;
+		this.noarkSchemasDirectory = noarkSchemasDirectory;
+
+		put(
+				"arkivstruktur.xml",
+				new Noark53PackageEntity(this, "arkivstruktur.xml", false, "arkivstruktur.xsd", "metadatakatalog.xsd"));
+		put("arkivuttrekk.xml", new Noark53PackageEntity(this, "arkivuttrekk.xml", false, "addml.xsd"));
+		put("endringslogg.xml", new Noark53PackageEntity(this, "endringslogg.xml", false, "endringslogg.xsd"));
+		put("loependeJournal.xml", new Noark53PackageEntity(this, "loependeJournal.xml", true, "loependeJournal.xsd"));
+		put(
+				"offentligJournal.xml",
+				new Noark53PackageEntity(this, "offentligJournal.xml", true, "offentligJournal.xsd"));
+	}
+
+	public File getExtractionDirectory() {
+
+		return extractionDirectory;
+	}
+
+	public File getNoarkSchemasDirectory() {
+
+		return noarkSchemasDirectory;
+	}
+
+	public List<File> getAllNoarkSchemaFiles() {
+
+		List<File> noarkSchemas = new ArrayList<>();
+
+		for (Noark53PackageEntity entity : values()) {
+			noarkSchemas.addAll(entity.getNoarkSchemas());
+		}
+
+		return Collections.unmodifiableList(noarkSchemas);
+	}
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XMLValidator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XMLValidator.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.documaster.validator.storage.model.BaseItem;
 import com.documaster.validator.validation.collector.ValidationCollector;
 import com.documaster.validator.validation.noark53.provider.ValidationGroup;
+import com.documaster.validator.validation.noark53.model.Noark53PackageEntity;
 import com.documaster.validator.validation.utils.SchemaValidator;
 import com.documaster.validator.validation.utils.WellFormedXmlValidator;
 import org.slf4j.Logger;
@@ -32,16 +33,16 @@ public class XMLValidator {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(XMLValidator.class);
 
-	public static boolean validate(File xmlFile, List<File> xsdSchemas, boolean ignoreNonComplianceToSchema) {
+	public static boolean validate(Noark53PackageEntity entity, boolean ignoreNonComplianceToSchema) {
 
-		LOGGER.info("Validating XML File {} ...", xmlFile);
+		LOGGER.info("Validating XML File {} ...", entity.getXmlFile());
 
 		ValidationCollector.ValidationResult result = new ValidationCollector.ValidationResult(
-				xmlFile.getName() + " integrity", ValidationGroup.COMMON);
+				entity.getXmlFileName() + " integrity", ValidationGroup.COMMON);
 
-		boolean exists = validateExistence(xmlFile, result);
-		boolean isWellFormed = validateIntegrity(xmlFile, result);
-		boolean compliesWithSchemas = validateSchemaCompliance(xmlFile, result, xsdSchemas);
+		boolean exists = validateExistence(entity.getXmlFile(), result);
+		boolean isWellFormed = validateIntegrity(entity.getXmlFile(), result);
+		boolean compliesWithSchemas = validateSchemaCompliance(entity.getXmlFile(), result, entity.getNoarkSchemas());
 
 		ValidationCollector.get().collect(result);
 

--- a/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xml
+++ b/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xml
@@ -2140,7 +2140,8 @@
                         FROM arkivstruktur.registrering
                         WHERE _dtype = 'journalpost'
                     ) struktur
-                    WHERE running.value <> arkivuttrekk_count OR arkivuttrekk_count IS NULL;
+                    WHERE (arkivuttrekk_count IS NULL AND running.value > 0) OR
+                        (arkivuttrekk_count IS NOT NULL AND running.value <> arkivuttrekk_count);
                 ]]>
             </errors>
         </queries>
@@ -2313,7 +2314,8 @@
                         FROM arkivstruktur.registrering
                         WHERE _dtype = 'journalpost'
                     ) struktur
-                    WHERE running.value <> arkivuttrekk_count OR arkivuttrekk_count IS NULL;
+                    WHERE (arkivuttrekk_count IS NULL AND running.value > 0) OR
+                        (arkivuttrekk_count IS NOT NULL AND running.value <> arkivuttrekk_count);
                 ]]>
             </errors>
         </queries>


### PR DESCRIPTION
The necessity to store more information about a single Noark 5.3
extraction package entity required that the way we represent it in the
model is refactored. This commit introduces the Noark53PackageEntity
that represents a single Noark 5.3 XML file, its corresponding XSD
schemas (both Noark-distributed and contained in the extraction
package), and a boolean value indicating whether it is mandatory. This
class and the Noark53PackageStructure were extracted as stand-alone
classes.

In addition to the above refactoring, loependeJournal.xml and
offentligJournal.xml are now considered optional in the Noark 5.3
extraction package.

Fixes issue #2.