### PR TITLE
Validate against distributed schemas

### DIFF
--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
@@ -171,11 +171,11 @@ public class Noark53Validator extends Validator<Noark53Command> {
 
 			// Validate the extraction-distributed XSD schemas
 			for (File xsdSchema : entity.getPackageSchemas()) {
-				XSDValidator.validate(xsdSchema, getCommand().getProperties().getChecksumFor(xsdSchema.getName()));
+				XSDValidator.isValid(xsdSchema, getCommand().getProperties().getChecksumFor(xsdSchema.getName()));
 			}
 
 			// Validate the extraction-distributed XML files
-			boolean isXMLValid = XMLValidator.validate(entity, getCommand().getIgnoreNonCompliantXML());
+			boolean isXMLValid = XMLValidator.isValid(entity, getCommand().getIgnoreNonCompliantXML());
 			stopValidation = stopValidation || !isXMLValid;
 		}
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XSDValidator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XSDValidator.java
@@ -31,7 +31,7 @@ public class XSDValidator {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(XSDValidator.class);
 
-	public static boolean validate(File xsdFile, String checksum) {
+	public static boolean isValid(File xsdFile, String checksum) {
 
 		LOGGER.info("Validating XSD File {} ...", xsdFile);
 


### PR DESCRIPTION
The Noark 5.3 validator will now also validate the XML files
in the extraction package against the XSD schemas in the
extraction package. This validation is purely informational and
will produce warnings in case of failure.

Fixes issue #7.

This PR is based on PRs #9 and #10. I suggest that they are reviewed first.