### PR TITLE
Fix duplicate System IDs in Extraction-wide System ID Uniqueness test

### DIFF
--- a/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xml
+++ b/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xml
@@ -422,9 +422,13 @@
                             UNION ALL
                                 SELECT systemid
                                 FROM arkivstruktur.klassifikasjonssystem
+                                GROUP BY systemid, avsluttetdato, avsluttetav, opprettetdato, _dtype, tittel,
+                                    klassifikasjonstype, opprettetav, beskrivelse
                             UNION ALL
                                 SELECT systemid
                                 FROM arkivstruktur.klasse
+                                GROUP BY _ref_klasse, systemid, avsluttetdato, _dtype, tittel, klasseid,
+                                    noekkelord, avsluttetav, opprettetdato, opprettetav, beskrivelse
                             UNION ALL
                                 SELECT systemid
                                 FROM arkivstruktur.mappe
@@ -451,9 +455,13 @@
                         UNION ALL
                             SELECT 'klassifikasjonssystem' entity, systemid
                             FROM arkivstruktur.klassifikasjonssystem
+                            GROUP BY systemid, avsluttetdato, avsluttetav, opprettetdato, _dtype, tittel,
+                                klassifikasjonstype, opprettetav, beskrivelse
                         UNION ALL
                             SELECT 'klasse' entity, systemid
                             FROM arkivstruktur.klasse
+                            GROUP BY _ref_klasse, systemid, avsluttetdato, _dtype, tittel, klasseid,
+                                noekkelord, avsluttetav, opprettetdato, opprettetav, beskrivelse
                         UNION ALL
                             SELECT 'mappe' entity, systemid
                             FROM arkivstruktur.mappe


### PR DESCRIPTION
Previously, if a Classification system was linked to more than one
Series, the validator would erroneously count the system IDs of that
Classification system and its Classes as many times as there were
Series connected to it.

The issue stemmed from the fact that arkivstruktur.xml may list a
Classification system multiple times if multiple Series refer to it.
During parsing of arkivstruktur.xml, however, we have no means of
identifying whether we have encountered that specific Classification
System or not. As a result, we end up persisting the Classification
System and its Classes mutliple times.

To remedy the above, we now aggregate the Classification System and
Class System IDs when performing the Extraction-wide System ID
Uniqueness test.

Fixes issue #4.