### PR TITLE
Include execution information in reports

### DIFF
--- a/noark-extraction-validator/pom.xml
+++ b/noark-extraction-validator/pom.xml
@@ -138,7 +138,23 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>com.documaster.validator.main.Run</mainClass>
+							<addDefaultImplementationEntries>
+								true
+							</addDefaultImplementationEntries>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.4.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
@@ -18,16 +18,31 @@
 package com.documaster.validator.config.commands;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.ParametersDelegate;
 import com.documaster.validator.config.delegates.Delegate;
 import com.documaster.validator.config.properties.InternalProperties;
+import org.apache.commons.lang.StringUtils;
 
 public abstract class Command<T extends InternalProperties> {
 
+	private JCommander argParser;
+
+	public Command(JCommander argParser) {
+
+		this.argParser = argParser;
+	}
+
 	/**
-	 * Validates all instances marked with an {@link ParametersDelegate} annotation and of type {@link Delegate}.
+	 * Validates all {@link ParametersDelegate}s in this {@link Command}.
 	 *
 	 * @throws ParameterException
 	 * 		if the validation fails
@@ -35,17 +50,27 @@ public abstract class Command<T extends InternalProperties> {
 	public void validate() throws ParameterException {
 
 		for (Field field : getClass().getDeclaredFields()) {
-
-			if (field.getAnnotation(ParametersDelegate.class) != null && field.getType()
-					.isAssignableFrom(Delegate.class)) {
-
+			if (field.getAnnotation(ParametersDelegate.class) != null && Delegate.class
+					.isAssignableFrom(field.getType())) {
 				try {
+					field.setAccessible(true);
 					((Delegate) field.get(this)).validate();
 				} catch (IllegalAccessException ex) {
-					throw new ParameterException("Could not access delegate", ex);
+					throw new ParameterException("Could not access delegate " + field.getName(), ex);
 				}
 			}
 		}
+	}
+
+	public ExecutionInfo getExecutionInfo() {
+
+		List<ParameterInfo> parameters = new ArrayList<>();
+
+		for (ParameterDescription param : argParser.getCommands().get(getName()).getParameters()) {
+			parameters.add(new ParameterInfo(param));
+		}
+
+		return new ExecutionInfo(parameters);
 	}
 
 	/**
@@ -57,4 +82,87 @@ public abstract class Command<T extends InternalProperties> {
 	 * Retrieves the {@link InternalProperties} associated with the command.
 	 */
 	public abstract T getProperties() throws Exception;
+
+	public static class ExecutionInfo {
+
+		List<ParameterInfo> parameterInfo;
+
+		ExecutionInfo(List<ParameterInfo> parameterInfo) {
+
+			this.parameterInfo = parameterInfo;
+		}
+
+		/**
+		 * Retrieves information about the parameters used in this execution.
+		 */
+		public List<ParameterInfo> getParameterInfo() {
+
+			return parameterInfo;
+		}
+
+		/**
+		 * Retrieves general (usually static) information about this execution, such as:
+		 * <ul>
+		 * <li>Build version</li>
+		 * </ul>
+		 */
+		public Map<String, Object> getGeneralInfo() {
+
+			Map<String, Object> generalInfo = new HashMap<>();
+			generalInfo.put("Version", getClass().getPackage().getImplementationVersion());
+
+			return Collections.unmodifiableMap(generalInfo);
+		}
+	}
+
+	/**
+	 * A wrapper around the {@link JCommander} {@link ParameterDescription}.
+	 */
+	public static class ParameterInfo {
+
+		private String name;
+		private Object specifiedValue;
+		private Object defaultValue;
+		private String description;
+		private boolean required;
+
+		ParameterInfo(ParameterDescription param) {
+
+			this.name = !StringUtils.isBlank(param.getNames()) ? param.getNames() : param.getParameterized().getName();
+			this.specifiedValue = param.getParameterized().get(param.getObject());
+			this.defaultValue = param.getDefault();
+			this.description = param.getDescription();
+			this.required = param.getParameter().required();
+		}
+
+		public String getName() {
+
+			return name;
+		}
+
+		public Object getSpecifiedValue() {
+
+			return specifiedValue;
+		}
+
+		public Object getDefaultValue() {
+
+			return defaultValue;
+		}
+
+		public String getDescription() {
+
+			return description;
+		}
+
+		public boolean isRequired() {
+
+			return required;
+		}
+
+		public boolean isDefault() {
+
+			return specifiedValue == null || specifiedValue.equals(defaultValue);
+		}
+	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Noark53Command.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Noark53Command.java
@@ -23,14 +23,16 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.beust.jcommander.converters.FileConverter;
-import com.documaster.validator.config.delegates.ReporterDelegate;
-import com.documaster.validator.config.delegates.StorageDelegate;
+import com.documaster.validator.config.delegates.ConfigurableReporting;
+import com.documaster.validator.config.delegates.ConfigurableStorage;
+import com.documaster.validator.config.delegates.ReportConfiguration;
+import com.documaster.validator.config.delegates.StorageConfiguration;
 import com.documaster.validator.config.properties.Noark53Properties;
 import com.documaster.validator.config.validators.DirectoryValidator;
 
 @Parameters(commandNames = Noark53Command.COMMAND_NAME,
 		commandDescription = "Validates a Noark 5.3 extraction package.")
-public class Noark53Command extends Command<Noark53Properties> {
+public class Noark53Command extends Command<Noark53Properties> implements ConfigurableReporting, ConfigurableStorage {
 
 	public static final String COMMAND_NAME = "noark53";
 
@@ -47,10 +49,10 @@ public class Noark53Command extends Command<Noark53Properties> {
 	private boolean ignoreNonCompliantXML = false;
 
 	@ParametersDelegate
-	private ReporterDelegate reporterDelegate = new ReporterDelegate();
+	private ReportConfiguration reportConfiguration = new ReportConfiguration();
 
 	@ParametersDelegate
-	private StorageDelegate storageDelegate = new StorageDelegate();
+	private StorageConfiguration storageConfiguration = new StorageConfiguration();
 
 	private Noark53Properties properties;
 
@@ -64,14 +66,16 @@ public class Noark53Command extends Command<Noark53Properties> {
 		return ignoreNonCompliantXML;
 	}
 
-	public ReporterDelegate getReporterDelegate() {
+	@Override
+	public ReportConfiguration getReportConfiguration() {
 
-		return reporterDelegate;
+		return reportConfiguration;
 	}
 
-	public StorageDelegate getStorageDelegate() {
+	@Override
+	public StorageConfiguration getStorageConfiguration() {
 
-		return storageDelegate;
+		return storageConfiguration;
 	}
 
 	@Override

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Noark53Command.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Noark53Command.java
@@ -19,6 +19,7 @@ package com.documaster.validator.config.commands;
 
 import java.io.File;
 
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
@@ -55,6 +56,11 @@ public class Noark53Command extends Command<Noark53Properties> implements Config
 	private StorageConfiguration storageConfiguration = new StorageConfiguration();
 
 	private Noark53Properties properties;
+
+	public Noark53Command(JCommander argParser) {
+
+		super(argParser);
+	}
 
 	public File getExtractionDirectory() {
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableReporting.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableReporting.java
@@ -1,6 +1,6 @@
 /**
  * Noark Extraction Validator
- * Copyright (C) 2016, Documaster AS
+ * Copyright (C) 2017, Documaster AS
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableReporting.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableReporting.java
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.reporting.core;
+package com.documaster.validator.config.delegates;
 
-public enum ReporterType {
+public interface ConfigurableReporting {
 
-	EXCEL_XLS, EXCEL_XLSX
+	ReportConfiguration getReportConfiguration();
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableStorage.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableStorage.java
@@ -1,6 +1,6 @@
 /**
  * Noark Extraction Validator
- * Copyright (C) 2016, Documaster AS
+ * Copyright (C) 2017, Documaster AS
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableStorage.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ConfigurableStorage.java
@@ -15,12 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.reporting.core;
+package com.documaster.validator.config.delegates;
 
-public interface Reporter {
+public interface ConfigurableStorage {
 
-	/**
-	 * Generates a report for the execution.
-	 */
-	void createReport();
+	StorageConfiguration getStorageConfiguration();
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ReportConfiguration.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ReportConfiguration.java
@@ -18,15 +18,21 @@
 package com.documaster.validator.config.delegates;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.converters.FileConverter;
 import com.documaster.validator.config.validators.DirectoryValidator;
 import com.documaster.validator.exceptions.ReportingException;
-import com.documaster.validator.reporting.core.ReporterType;
+import com.documaster.validator.reporting.ReportType;
 
-public class ReporterDelegate implements Delegate {
+import static com.documaster.validator.reporting.ReportType.EXCEL_XLSX;
+
+public class ReportConfiguration implements Delegate {
+
+	private static List<ReportType> defaultReportTypes;
 
 	private static final String OUTPUT_DIR = "-output-dir";
 	@Parameter(
@@ -36,36 +42,37 @@ public class ReporterDelegate implements Delegate {
 
 	private static final String OUTPUT_TYPE = "-output-type";
 	@Parameter(names = OUTPUT_TYPE, description = "The output type of the validation report")
-	private ReporterType reportType = ReporterType.EXCEL_XLSX;
+	private List<ReportType> outputTypes = defaultReportTypes;
+
+	static {
+		defaultReportTypes = new ArrayList<>();
+		defaultReportTypes.add(EXCEL_XLSX);
+	}
 
 	public File getOutputDir() {
 
 		return outputDir;
 	}
 
-	public ReporterType getOutputType() {
+	public List<ReportType> getOutputTypes() {
 
-		return reportType;
+		return outputTypes;
 	}
 
 	@Override
 	public void validate() {
 
-		if (reportType == null) {
-
-			throw new ParameterException(OUTPUT_TYPE + " must be specified.");
+		for (ReportType reportType : outputTypes) {
+			switch (reportType) {
+				case EXCEL_XLS:
+				case EXCEL_XLSX:
+					if (outputDir == null) {
+						throw new ParameterException(OUTPUT_DIR + " must be specified for " + reportType);
+					}
+					break;
+				default:
+					throw new ReportingException("Unknown report type: " + reportType);
+			}
 		}
-
-		switch (reportType) {
-			case EXCEL_XLS:
-			case EXCEL_XLSX:
-				if (outputDir == null) {
-					throw new ParameterException(OUTPUT_DIR + " must be specified");
-				}
-				break;
-			default:
-				throw new ReportingException("Unknown report type: " + reportType);
-		}
-
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/StorageConfiguration.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/StorageConfiguration.java
@@ -22,7 +22,7 @@ import com.beust.jcommander.ParameterException;
 import com.documaster.validator.exceptions.ReportingException;
 import com.documaster.validator.storage.core.Storage;
 
-public class StorageDelegate implements Delegate {
+public class StorageConfiguration implements Delegate {
 
 	private static final String STORAGE = "-storage";
 	@Parameter(names = STORAGE, description = "The storage type")

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/main/Run.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/main/Run.java
@@ -64,28 +64,23 @@ public class Run {
 	private static Command initConfiguration(String... args) throws ConfigurationException, IOException {
 
 		GlobalConfiguration globalConfig = new GlobalConfiguration();
-
-		Noark53Command noark53Command = new Noark53Command();
-
-		Map<String, Command> commands = new HashMap<>();
-		commands.put(Noark53Command.COMMAND_NAME, noark53Command);
-
 		JCommander argParser = new JCommander(globalConfig);
 
-		argParser.addCommand(noark53Command);
+		Map<String, Command> commands = new HashMap<>();
+		commands.put(Noark53Command.COMMAND_NAME, new Noark53Command(argParser));
+		for (Command command : commands.values()) {
+			argParser.addCommand(command);
+		}
 
 		argParser.parse(args);
-
 		if (args.length == 0 || globalConfig.showHelp()) {
-
 			argParser.usage();
 			System.exit(0);
 		}
 
-		String parsedCommandName = argParser.getParsedCommand();
+		Command command = commands.get(argParser.getParsedCommand());
+		command.validate();
 
-		commands.get(parsedCommandName).validate();
-
-		return commands.get(parsedCommandName);
+		return command;
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/Report.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/Report.java
@@ -15,26 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.reporting.core;
+package com.documaster.validator.reporting;
 
-import com.documaster.validator.config.delegates.ReporterDelegate;
-import com.documaster.validator.exceptions.ReportingException;
-import com.documaster.validator.reporting.excel.ExcelReporter;
+public interface Report {
 
-public class ReporterFactory {
-
-	private ReporterFactory() {
-		// Prevent instantiation
-	}
-
-	public static Reporter createReporter(ReporterDelegate config, String title) {
-
-		switch (config.getOutputType()) {
-			case EXCEL_XLS:
-			case EXCEL_XLSX:
-				return new ExcelReporter(config.getOutputDir(), config.getOutputType(), title);
-			default:
-				throw new ReportingException("Unknown report type: " + config.getOutputType());
-		}
-	}
+	/**
+	 * Generates the report.
+	 */
+	void generate() throws Exception;
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/Report.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/Report.java
@@ -17,10 +17,33 @@
  */
 package com.documaster.validator.reporting;
 
-public interface Report {
+import com.documaster.validator.config.commands.Command;
+import com.documaster.validator.config.delegates.ConfigurableReporting;
+
+public abstract class Report<T extends Command<?> & ConfigurableReporting> {
+
+	private T config;
+
+	private String title;
+
+	Report(T config, String title) {
+
+		this.config = config;
+		this.title = title;
+	}
+
+	protected T getConfig() {
+
+		return config;
+	}
+
+	protected String getTitle() {
+
+		return title;
+	}
 
 	/**
 	 * Generates the report.
 	 */
-	void generate() throws Exception;
+	abstract void generate() throws Exception;
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportFactory.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportFactory.java
@@ -19,7 +19,8 @@ package com.documaster.validator.reporting;
 
 import java.util.EnumSet;
 
-import com.documaster.validator.config.delegates.ReportConfiguration;
+import com.documaster.validator.config.commands.Command;
+import com.documaster.validator.config.delegates.ConfigurableReporting;
 import com.documaster.validator.exceptions.ReportingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,10 +33,10 @@ public class ReportFactory {
 		// Prevent instantiation
 	}
 
-	public static void generateReports(ReportConfiguration config, String title) {
+	public static <T extends Command<?> & ConfigurableReporting> void generateReports(T config, String title) {
 
 		EnumSet<ReportType> reportTypes = EnumSet.noneOf(ReportType.class);
-		reportTypes.addAll(config.getOutputTypes());
+		reportTypes.addAll(config.getReportConfiguration().getOutputTypes());
 
 		for (ReportType outputType : reportTypes) {
 			try {
@@ -45,7 +46,7 @@ public class ReportFactory {
 				switch (outputType) {
 					case EXCEL_XLS:
 					case EXCEL_XLSX:
-						new ExcelReport(config.getOutputDir(), outputType, title).generate();
+						new ExcelReport<>(config, outputType, title).generate();
 						break;
 					default:
 						throw new ReportingException("Unknown report type: " + outputType);
@@ -54,7 +55,7 @@ public class ReportFactory {
 				LOGGER.info("{} report generated.", outputType);
 
 			} catch (Exception ex) {
-				LOGGER.warn("Could not generate report " + outputType, ex);
+				LOGGER.error("Could not generate report " + outputType, ex);
 			}
 		}
 	}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportFactory.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportFactory.java
@@ -1,0 +1,61 @@
+/**
+ * Noark Extraction Validator
+ * Copyright (C) 2016, Documaster AS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.documaster.validator.reporting;
+
+import java.util.EnumSet;
+
+import com.documaster.validator.config.delegates.ReportConfiguration;
+import com.documaster.validator.exceptions.ReportingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReportFactory {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReportFactory.class);
+
+	private ReportFactory() {
+		// Prevent instantiation
+	}
+
+	public static void generateReports(ReportConfiguration config, String title) {
+
+		EnumSet<ReportType> reportTypes = EnumSet.noneOf(ReportType.class);
+		reportTypes.addAll(config.getOutputTypes());
+
+		for (ReportType outputType : reportTypes) {
+			try {
+
+				LOGGER.info("Generating {} report ...", outputType);
+
+				switch (outputType) {
+					case EXCEL_XLS:
+					case EXCEL_XLSX:
+						new ExcelReport(config.getOutputDir(), outputType, title).generate();
+						break;
+					default:
+						throw new ReportingException("Unknown report type: " + outputType);
+				}
+
+				LOGGER.info("{} report generated.", outputType);
+
+			} catch (Exception ex) {
+				LOGGER.warn("Could not generate report " + outputType, ex);
+			}
+		}
+	}
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportType.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportType.java
@@ -1,0 +1,23 @@
+/**
+ * Noark Extraction Validator
+ * Copyright (C) 2016, Documaster AS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.documaster.validator.reporting;
+
+public enum ReportType {
+
+	EXCEL_XLS, EXCEL_XLSX
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
@@ -30,24 +30,24 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 
-class ExcelUtils {
+public class ExcelUtils {
 
 	private ExcelUtils() {
 		// Prevent instantiation
 	}
 
-	static Row createRow(Sheet sheet) {
+	public static Row createRow(Sheet sheet) {
 
 		return createRow(null, sheet);
 	}
 
-	static Row createRow(Integer rowHeight, Sheet sheet) {
+	public static Row createRow(Integer rowHeight, Sheet sheet) {
 
 		int rowIndex = sheet.getLastRowNum() == 0 && sheet.getRow(0) == null ? 0 : sheet.getLastRowNum() + 1;
 		return createRow(rowIndex, rowHeight, sheet);
 	}
 
-	static Row createRow(int rowIndex, Integer rowHeightInPoints, Sheet sheet) {
+	public static Row createRow(int rowIndex, Integer rowHeightInPoints, Sheet sheet) {
 
 		Row row = sheet.createRow(rowIndex);
 
@@ -58,17 +58,17 @@ class ExcelUtils {
 		return row;
 	}
 
-	static Cell createCell(Object cellValue, int cellIndex, Row row) {
+	public static Cell createCell(Object cellValue, int cellIndex, Row row) {
 
 		return createCell(cellValue, cellIndex, null, row);
 	}
 
-	static Cell createCell(Object cellValue, int cellIndex, CellStyle style, Row row) {
+	public static Cell createCell(Object cellValue, int cellIndex, CellStyle style, Row row) {
 
 		return createCell(cellValue, cellIndex, style, row, null);
 	}
 
-	static Cell createCell(Object cellValue, int cellIndex, CellStyle style, Row row, Cell linkTo) {
+	public static Cell createCell(Object cellValue, int cellIndex, CellStyle style, Row row, Cell linkTo) {
 
 		Cell cell = row.createCell(cellIndex);
 		cell.setCellValue(cellValue.toString());
@@ -86,7 +86,7 @@ class ExcelUtils {
 		return cell;
 	}
 
-	static void addHyperLink(Cell fromCell, Cell toCell) {
+	public static void addHyperLink(Cell fromCell, Cell toCell) {
 
 		Hyperlink link = createHyperLinkTo(toCell);
 
@@ -101,7 +101,7 @@ class ExcelUtils {
 		return link;
 	}
 
-	static CellStyle createDefaultCellStyle(Workbook wb) {
+	public static CellStyle createDefaultCellStyle(Workbook wb) {
 
 		CellStyle style = wb.createCellStyle();
 
@@ -111,7 +111,7 @@ class ExcelUtils {
 		return style;
 	}
 
-	static void addBorderToStyle(EnumSet<BorderPosition> borderPositions, IndexedColors color, CellStyle style) {
+	public static void addBorderToStyle(EnumSet<BorderPosition> borderPositions, IndexedColors color, CellStyle style) {
 
 		for (BorderPosition position : borderPositions) {
 
@@ -139,13 +139,13 @@ class ExcelUtils {
 		}
 	}
 
-	static void addSolidFillToStyle(CellStyle style, IndexedColors color) {
+	public static void addSolidFillToStyle(CellStyle style, IndexedColors color) {
 
 		style.setFillForegroundColor(color.getIndex());
 		style.setFillPattern(CellStyle.SOLID_FOREGROUND);
 	}
 
-	static Font createDefaultFont(Workbook wb, short size, boolean bold) {
+	public static Font createDefaultFont(Workbook wb, short size, boolean bold) {
 
 		Font font = wb.createFont();
 
@@ -156,14 +156,14 @@ class ExcelUtils {
 		return font;
 	}
 
-	static void autoSizeColumns(Sheet sheet, int startCol, int endCol) {
+	public static void autoSizeColumns(Sheet sheet, int startCol, int endCol) {
 
 		for (int i = startCol; i <= endCol; i++) {
 			sheet.autoSizeColumn(i);
 		}
 	}
 
-	static void freezePanes(Sheet sheet, int numberOfRows, int numberOfColumns) {
+	public static void freezePanes(Sheet sheet, int numberOfRows, int numberOfColumns) {
 
 		sheet.createFreezePane(numberOfColumns, numberOfRows);
 	}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/Storage.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/Storage.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.documaster.validator.config.delegates.StorageDelegate;
+import com.documaster.validator.config.delegates.StorageConfiguration;
 import com.documaster.validator.exceptions.StorageException;
 import com.documaster.validator.storage.model.BaseItem;
 import com.documaster.validator.storage.model.Item;
@@ -55,11 +55,11 @@ public abstract class Storage {
 	 * to the storage provider, and runs a separate thread that listens for actions.
 	 *
 	 * @param config
-	 * 		The {@link StorageDelegate} with which to instantiate the {@link Storage}.
+	 * 		The {@link StorageConfiguration} with which to instantiate the {@link Storage}.
 	 * @param uniqueFields
 	 * 		The name of the unique field in each table
 	 */
-	public static void init(StorageDelegate config, Map<String, Set<String>> uniqueFields) throws Exception {
+	public static void init(StorageConfiguration config, Map<String, Set<String>> uniqueFields) throws Exception {
 
 		LOGGER.info("Initializing storage ...");
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/StorageFactory.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/StorageFactory.java
@@ -19,7 +19,7 @@ package com.documaster.validator.storage.core;
 
 import java.text.MessageFormat;
 
-import com.documaster.validator.config.delegates.StorageDelegate;
+import com.documaster.validator.config.delegates.StorageConfiguration;
 import com.documaster.validator.exceptions.StorageException;
 import com.documaster.validator.storage.database.DatabaseStorage;
 
@@ -29,7 +29,7 @@ public final class StorageFactory {
 		// Prevent instantiation
 	}
 
-	public static Storage createPersistence(StorageDelegate config) {
+	public static Storage createPersistence(StorageConfiguration config) {
 
 		switch (config.getStorageType()) {
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
@@ -120,7 +120,7 @@ public class Noark53Validator extends Validator<Noark53Command> {
 
 			FileUtils.deleteQuietly(structure.getNoarkSchemasDirectory());
 
-			ReportFactory.generateReports(getCommand().getReportConfiguration(), getArchiveTitle());
+			ReportFactory.generateReports(getCommand(), getArchiveTitle());
 
 			if (Storage.get() != null) {
 				Storage.get().stopWriter();

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
@@ -35,7 +35,7 @@ import javax.xml.parsers.SAXParserFactory;
 import com.documaster.validator.config.commands.Noark53Command;
 import com.documaster.validator.converters.xsd.XsdConverter;
 import com.documaster.validator.exceptions.ValidationException;
-import com.documaster.validator.reporting.core.ReporterFactory;
+import com.documaster.validator.reporting.ReportFactory;
 import com.documaster.validator.storage.core.Storage;
 import com.documaster.validator.storage.model.BaseItem;
 import com.documaster.validator.storage.model.Field;
@@ -87,7 +87,7 @@ public class Noark53Validator extends Validator<Noark53Command> {
 			validateStructure();
 
 			// Init storage
-			Storage.init(getCommand().getStorageDelegate(), getCommand().getProperties().getUniqueFieldsMap());
+			Storage.init(getCommand().getStorageConfiguration(), getCommand().getProperties().getUniqueFieldsMap());
 			Storage.get().connect();
 			Storage.get().startWriter();
 
@@ -120,7 +120,7 @@ public class Noark53Validator extends Validator<Noark53Command> {
 
 			FileUtils.deleteQuietly(structure.getNoarkSchemasDirectory());
 
-			ReporterFactory.createReporter(getCommand().getReporterDelegate(), getArchiveTitle()).createReport();
+			ReportFactory.generateReports(getCommand().getReportConfiguration(), getArchiveTitle());
 
 			if (Storage.get() != null) {
 				Storage.get().stopWriter();


### PR DESCRIPTION
Refactored reporting:
* ReportFactory now generates reports instead of returning Report
instances
* Reporter --> Report
* Made the ExcelReport constructor package-private so that only
the ReportFactory has access to it
* Made all static ExcelUtils methods public so that they can be used
outside of its package
* Added support for generating multiple reports during a single run
* Moved error handling from the report instance to the ReportFactory

Refactored configuration delegates:
* Renamed *Delegate to *Configuration to improve code readability

Added support for printing execution information in validation reports:
* Added maven-jar-plugin to ease the retrieval of the validator version during run-time
* Retrieve parameter information from the JCommander argument parser
* Added Execution Sheet in the Excel Report

Implements enhancement #13.