### PR TITLE
Enhance Noark 5.3 validation framework

### DIFF
--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
@@ -109,7 +109,7 @@ public abstract class Command<T extends InternalProperties> {
 		public Map<String, Object> getGeneralInfo() {
 
 			Map<String, Object> generalInfo = new HashMap<>();
-			generalInfo.put("Version", getClass().getPackage().getImplementationVersion());
+			generalInfo.put("version", getClass().getPackage().getImplementationVersion());
 
 			return Collections.unmodifiableMap(generalInfo);
 		}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
@@ -31,6 +31,7 @@ import com.documaster.validator.config.commands.Command;
 import com.documaster.validator.config.delegates.ConfigurableReporting;
 import com.documaster.validator.storage.model.BaseItem;
 import com.documaster.validator.validation.collector.ValidationCollector;
+import com.documaster.validator.validation.collector.ValidationResult;
 import com.documaster.validator.validation.utils.DefaultXMLHandler;
 import com.documaster.validator.validation.utils.SchemaValidator;
 import org.apache.commons.io.FileUtils;
@@ -126,14 +127,13 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 		attr("warn", ValidationCollector.get().getTotalWarningCount());
 		attr("error", ValidationCollector.get().getTotalErrorCount());
 
-		for (Map.Entry<String, List<ValidationCollector.ValidationResult>> group : ValidationCollector.get()
+		for (Map.Entry<String, List<ValidationResult>> group : ValidationCollector.get()
 				.getAllResults().entrySet()) {
 
 			startGroup(group.getKey());
 
-			int testIndex = 0;
-			for (ValidationCollector.ValidationResult test : group.getValue()) {
-				startTest(test, ++testIndex);
+			for (ValidationResult test : group.getValue()) {
+				startTest(test);
 				end();
 			}
 			// End group
@@ -147,15 +147,13 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 
 		start("details");
 
-		for (Map.Entry<String, List<ValidationCollector.ValidationResult>> group : ValidationCollector.get()
-				.getAllResults().entrySet()) {
+		for (Map.Entry<String, List<ValidationResult>> group : ValidationCollector.get().getAllResults().entrySet()) {
 
 			startGroup(group.getKey());
 
-			int testIndex = 0;
-			for (ValidationCollector.ValidationResult test : group.getValue()) {
+			for (ValidationResult test : group.getValue()) {
 
-				startTest(test, ++testIndex);
+				startTest(test);
 
 				testDetails("info", test.getInformation());
 				testDetails("warn", test.getWarnings());
@@ -206,12 +204,13 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 		attr("error", ValidationCollector.get().getErrorCountIn(groupName));
 	}
 
-	private void startTest(ValidationCollector.ValidationResult test, int testIndex) throws XMLStreamException {
+	private void startTest(ValidationResult test) throws XMLStreamException {
 
 		start("test");
 
-		attr("id", test.getIdentifierPrefix() + testIndex);
+		attr("id", test.getId());
 		attr("name", test.getTitle());
+		attr("description", test.getDescription());
 		attr("info", test.getInformation().size());
 		attr("warn", test.getWarnings().size());
 		attr("error", test.getErrors().size());

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
@@ -36,6 +36,13 @@ public class ExcelUtils {
 		// Prevent instantiation
 	}
 
+	public static Row createStyledRow(Sheet sheet, CellStyle style) {
+
+		Row row = createRow(sheet);
+		row.setRowStyle(style);
+		return row;
+	}
+
 	public static Row createRow(Sheet sheet) {
 
 		return createRow(null, sheet);

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationCollector.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationCollector.java
@@ -19,9 +19,6 @@ package com.documaster.validator.validation.collector;
 
 import java.util.*;
 
-import com.documaster.validator.storage.model.BaseItem;
-import com.documaster.validator.validation.noark53.provider.ValidationGroup;
-
 /**
  * Collects information about the executed validation.
  */
@@ -32,18 +29,14 @@ public class ValidationCollector {
 	private Map<String, List<ValidationResult>> results;
 
 	private int totalInformationCount = 0;
-
 	private int totalWarningCount = 0;
-
 	private int totalErrorCount = 0;
 
 	private Map<String, Integer> informationCount;
-
 	private Map<String, Integer> warningCount;
-
 	private Map<String, Integer> errorCount;
 
-	private Map<String, ValidationStatusCode> statusCodes;
+	private Map<String, ValidationStatus> statuses;
 
 	private ValidationCollector() {
 
@@ -52,13 +45,12 @@ public class ValidationCollector {
 		informationCount = new HashMap<>();
 		warningCount = new HashMap<>();
 		errorCount = new HashMap<>();
-		statusCodes = new HashMap<>();
+		statuses = new HashMap<>();
 	}
 
 	public static ValidationCollector get() {
 
 		if (instance == null) {
-
 			instance = new ValidationCollector();
 		}
 
@@ -85,209 +77,63 @@ public class ValidationCollector {
 		return totalErrorCount;
 	}
 
-	public int getInformationCountIn(String group) {
+	public int getInformationCountIn(String groupName) {
 
-		return informationCount.containsKey(group) ? informationCount.get(group) : 0;
+		return informationCount.containsKey(groupName) ? informationCount.get(groupName) : 0;
 	}
 
-	public int getWarningCountIn(String group) {
+	public int getWarningCountIn(String groupName) {
 
-		return warningCount.containsKey(group) ? warningCount.get(group) : 0;
+		return warningCount.containsKey(groupName) ? warningCount.get(groupName) : 0;
 	}
 
-	public int getErrorCountIn(String group) {
+	public int getErrorCountIn(String groupName) {
 
-		return errorCount.containsKey(group) ? errorCount.get(group) : 0;
+		return errorCount.containsKey(groupName) ? errorCount.get(groupName) : 0;
 	}
 
-	public ValidationStatusCode getGroupStatus(String group) {
+	public int getTotalResultCountIn(String groupName) {
 
-		return statusCodes.containsKey(group) ? statusCodes.get(group) : null;
+		return results.get(groupName) != null ? results.get(groupName).size() : 0;
+	}
+
+	public ValidationStatus getGroupStatus(String groupName) {
+
+		return statuses.get(groupName);
 	}
 
 	public void collect(ValidationResult result) {
 
-		String group = result.getGroup().value();
+		String groupName = result.getGroupName();
 
-		if (results.containsKey(group)) {
+		if (results.containsKey(groupName)) {
 
-			results.get(group).add(result);
+			results.get(groupName).add(result);
 
 		} else {
 
-			results.put(group, new ArrayList<>(Collections.singletonList(result)));
+			results.put(groupName, new ArrayList<>(Collections.singletonList(result)));
 		}
 
-		putOrIncrementMapCounter(informationCount, group, result.getInformation().size());
-		putOrIncrementMapCounter(warningCount, group, result.getWarnings().size());
-		putOrIncrementMapCounter(errorCount, group, result.getErrors().size());
+		putOrIncrementMapCounter(informationCount, groupName, result.getInformation().size());
+		putOrIncrementMapCounter(warningCount, groupName, result.getWarnings().size());
+		putOrIncrementMapCounter(errorCount, groupName, result.getErrors().size());
 
 		totalInformationCount += result.getInformation().size();
 		totalWarningCount += result.getWarnings().size();
 		totalErrorCount += result.getErrors().size();
 
-		if (!statusCodes.containsKey(group) || result.getStatusCode().getCode() > statusCodes.get(group).getCode()) {
-
-			statusCodes.put(group, result.getStatusCode());
+		if (!statuses.containsKey(groupName) || result.getStatus().isMoreSevereThan(statuses.get(groupName))) {
+			statuses.put(groupName, result.getStatus());
 		}
 	}
 
 	private static void putOrIncrementMapCounter(Map<String, Integer> map, String key, int size) {
 
 		if (map.containsKey(key)) {
-
 			map.put(key, map.get(key) + size);
-
 		} else {
-
 			map.put(key, size);
-		}
-	}
-
-	public static class ValidationResult {
-
-		private String identifierPrefix;
-
-		private String title;
-
-		private ValidationGroup group;
-
-		private List<BaseItem> information;
-
-		private List<BaseItem> warnings;
-
-		private List<BaseItem> errors;
-
-		private ValidationStatusCode code;
-
-		public ValidationResult(String title, ValidationGroup group) {
-
-			this.identifierPrefix = ValidationGroup.getIdentifierOf(group);
-
-			this.title = title;
-
-			this.group = group;
-		}
-
-		public String getIdentifierPrefix() {
-
-			return identifierPrefix;
-		}
-
-		public String getTitle() {
-
-			return title;
-		}
-
-		public ValidationGroup getGroup() {
-
-			return group;
-		}
-
-		public List<BaseItem> getInformation() {
-
-			if (information == null) {
-
-				information = new ArrayList<>();
-			}
-
-			return information;
-		}
-
-		public void addInformation(BaseItem informationEntry) {
-
-			getInformation().add(informationEntry);
-		}
-
-		public void addInformation(List<BaseItem> informationEntries) {
-
-			getInformation().addAll(informationEntries);
-		}
-
-		public List<BaseItem> getWarnings() {
-
-			if (warnings == null) {
-
-				warnings = new ArrayList<>();
-			}
-
-			return warnings;
-		}
-
-		public void addWarning(BaseItem warningEntry) {
-
-			getWarnings().add(warningEntry);
-		}
-
-		public void addWarnings(List<BaseItem> warningEntries) {
-
-			getWarnings().addAll(warningEntries);
-		}
-
-		public List<BaseItem> getErrors() {
-
-			if (errors == null) {
-
-				errors = new ArrayList<>();
-			}
-
-			return errors;
-		}
-
-		public void addError(BaseItem errorEntry) {
-
-			getErrors().add(errorEntry);
-		}
-
-		public void addErrors(List<BaseItem> errorEntries) {
-
-			getErrors().addAll(errorEntries);
-		}
-
-		public ValidationStatusCode getStatusCode() {
-
-			if (code == null) {
-
-				if (errors != null && !errors.isEmpty()) {
-
-					code = ValidationStatusCode.ERROR;
-
-				} else {
-
-					if (warnings != null && !warnings.isEmpty()) {
-
-						code = ValidationStatusCode.WARNING;
-
-					} else {
-
-						code = ValidationStatusCode.SUCCESS;
-					}
-				}
-			}
-
-			return code;
-		}
-	}
-
-	/**
-	 * Defines status codes to use in the validation. Status codes with higher severity have higher
-	 * integer value. This is helpful when evaluating whether one status code is more/less severe
-	 * than another.
-	 */
-	public enum ValidationStatusCode {
-
-		SUCCESS(0), WARNING(1), ERROR(2);
-
-		private int code;
-
-		ValidationStatusCode(int code) {
-
-			this.code = code;
-		}
-
-		public int getCode() {
-
-			return code;
 		}
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationResult.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationResult.java
@@ -1,0 +1,126 @@
+/**
+ * Noark Extraction Validator
+ * Copyright (C) 2017, Documaster AS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.documaster.validator.validation.collector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.documaster.validator.storage.model.BaseItem;
+
+public class ValidationResult {
+
+	private String id;
+	private String title;
+	private String description;
+	private String groupName;
+
+	private List<BaseItem> information = new ArrayList<>();
+	private List<BaseItem> warnings = new ArrayList<>();
+	private List<BaseItem> errors = new ArrayList<>();
+
+	private ValidationStatus code;
+
+	public ValidationResult(String id, String title, String description, String groupName) {
+
+		this.id = id;
+		this.title = title;
+		this.description = description;
+		this.groupName = groupName;
+	}
+
+	public String getId() {
+
+		return id;
+	}
+
+	public String getTitle() {
+
+		return title;
+	}
+
+	public String getDescription() {
+
+		return description;
+	}
+
+	public String getGroupName() {
+
+		return groupName;
+	}
+
+	public List<BaseItem> getInformation() {
+
+		return information;
+	}
+
+	public void addInformation(BaseItem informationEntry) {
+
+		getInformation().add(informationEntry);
+	}
+
+	public void addInformation(List<BaseItem> informationEntries) {
+
+		getInformation().addAll(informationEntries);
+	}
+
+	public List<BaseItem> getWarnings() {
+
+		return warnings;
+	}
+
+	public void addWarning(BaseItem warningEntry) {
+
+		getWarnings().add(warningEntry);
+	}
+
+	public void addWarnings(List<BaseItem> warningEntries) {
+
+		getWarnings().addAll(warningEntries);
+	}
+
+	public List<BaseItem> getErrors() {
+
+		return errors;
+	}
+
+	public void addError(BaseItem errorEntry) {
+
+		getErrors().add(errorEntry);
+	}
+
+	public void addErrors(List<BaseItem> errorEntries) {
+
+		getErrors().addAll(errorEntries);
+	}
+
+	public ValidationStatus getStatus() {
+
+		if (code == null) {
+			if (errors != null && !errors.isEmpty()) {
+				code = ValidationStatus.ERROR;
+			} else {
+				if (warnings != null && !warnings.isEmpty()) {
+					code = ValidationStatus.WARNING;
+				} else {
+					code = ValidationStatus.SUCCESS;
+				}
+			}
+		}
+		return code;
+	}
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationStatus.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationStatus.java
@@ -1,6 +1,6 @@
 /**
  * Noark Extraction Validator
- * Copyright (C) 2016, Documaster AS
+ * Copyright (C) 2017, Documaster AS
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -15,45 +15,25 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.reporting.excel;
+package com.documaster.validator.validation.collector;
 
-public enum StyleName {
+/**
+ * Defines validation status codes. Status codes with higher severity have higher integer value. This is helpful when
+ * evaluating the severity of one status compared to another's.
+ */
+public enum ValidationStatus {
 
-	LINK("link"),
+	SUCCESS(0), WARNING(1), ERROR(2);
 
-	GROUP("summaryGroup"),
+	private int code;
 
-	RESULT_TITLE("summaryTitle"),
+	ValidationStatus(int code) {
 
-	RESULT_SUCCESS("summarySuccess"),
-
-	RESULT_WARNING("summaryWarning"),
-
-	RESULT_FAILURE("summaryFailure"),
-
-	RESULT_TITLE_SUCCESS("detailedTitleSuccess"),
-
-	RESULT_TITLE_WARNING("detailedTitleWarning"),
-
-	RESULT_TITLE_FAILURE("detailedTitleError"),
-
-	RESULT_DESCRIPTION("detailedDescription"),
-
-	RESULT_TYPE("detailedType"),
-
-	RESULT_HEADER_ROW("detailedHeaderRow"),
-
-	RESULT_ROW("detailedRow");
-
-	private String name;
-
-	private StyleName(String name) {
-
-		this.name = name;
+		this.code = code;
 	}
 
-	public String getName() {
+	public boolean isMoreSevereThan(ValidationStatus otherStatus) {
 
-		return name;
+		return code > otherStatus.code;
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/parsers/BaseHandler.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/parsers/BaseHandler.java
@@ -172,6 +172,6 @@ public class BaseHandler extends DefaultHandler {
 
 	String getItemDefNameForElement(String elementName) {
 
-		return getValidationGroup().value() + "." + elementName.toLowerCase();
+		return getValidationGroup().getName() + "." + elementName.toLowerCase();
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/parsers/TransferExportsHandler.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/parsers/TransferExportsHandler.java
@@ -50,7 +50,7 @@ class TransferExportsHandler extends BaseHandler {
 		characters.setLength(0);
 		String elementName = qName.toLowerCase();
 
-		if (getItemDefs().containsKey(getValidationGroup().value() + "." + elementName)) {
+		if (getItemDefs().containsKey(getValidationGroup().getName() + "." + elementName)) {
 
 			Map<String, String> attributeMap = new HashMap<>();
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/ValidationGroup.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/ValidationGroup.java
@@ -17,63 +17,58 @@
  */
 package com.documaster.validator.validation.noark53.provider;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlType;
+
+import com.documaster.validator.validation.collector.ValidationCollector;
 
 @XmlType(name = "group")
 @XmlEnum
 public enum ValidationGroup {
 
 	@XmlEnumValue("arkivstruktur")
-	ARCHIVE_STRUCTURE("arkivstruktur"),
+	ARCHIVE_STRUCTURE("arkivstruktur", "AS"),
 
 	@XmlEnumValue("loependejournal")
-	RUNNING_JOURNAL("loependejournal"),
+	RUNNING_JOURNAL("loependejournal", "LJ"),
 
 	@XmlEnumValue("offentligjournal")
-	PUBLIC_JOURNAL("offentligjournal"),
+	PUBLIC_JOURNAL("offentligjournal", "OJ"),
 
 	@XmlEnumValue("arkivuttrekk")
-	TRANSFER_EXPORTS("addml"),
+	TRANSFER_EXPORTS("addml", "AU"),
 
 	@XmlEnumValue("endringslogg")
-	CHANGE_LOG("endringslogg"),
+	CHANGE_LOG("endringslogg", "EL"),
 
-	@XmlEnumValue("common")
-	COMMON("common");
+	@XmlEnumValue("package")
+	PACKAGE("package", "P"),
 
-	private final String value;
+	@XmlEnumValue("exceptions")
+	EXCEPTIONS("exceptions", "E");
 
-	private static Map<String, String> identifierMap;
+	private final String name;
+	private final String prefix;
 
-	static {
+	ValidationGroup(String name, String prefix) {
 
-		identifierMap = new HashMap<>();
-
-		identifierMap.put(ARCHIVE_STRUCTURE.value(), "AS");
-		identifierMap.put(RUNNING_JOURNAL.value(), "LJ");
-		identifierMap.put(PUBLIC_JOURNAL.value(), "OJ");
-		identifierMap.put(TRANSFER_EXPORTS.value(), "AU");
-		identifierMap.put(CHANGE_LOG.value(), "EL");
-		identifierMap.put(COMMON.value(), "C");
+		this.name = name;
+		this.prefix = prefix;
 	}
 
-	ValidationGroup(String v) {
+	public String getName() {
 
-		value = v;
+		return name;
 	}
 
-	public String value() {
+	public String getGroupPrefix() {
 
-		return value;
+		return prefix;
 	}
 
-	public static String getIdentifierOf(ValidationGroup group) {
+	public String getNextGroupId() {
 
-		return identifierMap.get(group.value());
+		return prefix + (ValidationCollector.get().getTotalResultCountIn(name) + 1);
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/ValidationProvider.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/ValidationProvider.java
@@ -17,13 +17,16 @@
  */
 package com.documaster.validator.validation.noark53.provider;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import com.documaster.validator.validation.noark53.provider.rules.Check;
+import com.documaster.validator.validation.noark53.provider.rules.Test;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "validation")
@@ -32,24 +35,33 @@ public class ValidationProvider {
 	@XmlElement(required = true, name = "target")
 	protected String target;
 
-	@XmlElement(required = true, name = "rule")
-	protected List<ValidationRule> rules;
+	@XmlElement(required = true, name = "test")
+	protected List<Test> tests;
 
-	public ValidationProvider() {
-
-	}
+	@XmlElement(required = true, name = "check")
+	protected List<Check> checks;
 
 	public String getTarget() {
 
 		return target;
 	}
 
-	public List<ValidationRule> getRules() {
+	public List<Test> getTests() {
 
-		if (rules == null) {
-			rules = new ArrayList<>();
+		if (tests == null) {
+			return Collections.emptyList();
 		}
 
-		return this.rules;
+		return this.tests;
 	}
+
+	public List<Check> getChecks() {
+
+		if (checks == null) {
+			return Collections.emptyList();
+		}
+
+		return this.checks;
+	}
+
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/data/Data.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/data/Data.java
@@ -1,6 +1,6 @@
 /**
  * Noark Extraction Validator
- * Copyright (C) 2016, Documaster AS
+ * Copyright (C) 2017, Documaster AS
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -15,45 +15,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.reporting.excel;
+package com.documaster.validator.validation.noark53.provider.data;
 
-public enum StyleName {
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
-	LINK("link"),
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "queries")
+public class Data {
 
-	GROUP("summaryGroup"),
+	@XmlElement(required = true, name = "info")
+	private String infoRequest;
 
-	RESULT_TITLE("summaryTitle"),
+	public String getInfoRequest() {
 
-	RESULT_SUCCESS("summarySuccess"),
-
-	RESULT_WARNING("summaryWarning"),
-
-	RESULT_FAILURE("summaryFailure"),
-
-	RESULT_TITLE_SUCCESS("detailedTitleSuccess"),
-
-	RESULT_TITLE_WARNING("detailedTitleWarning"),
-
-	RESULT_TITLE_FAILURE("detailedTitleError"),
-
-	RESULT_DESCRIPTION("detailedDescription"),
-
-	RESULT_TYPE("detailedType"),
-
-	RESULT_HEADER_ROW("detailedHeaderRow"),
-
-	RESULT_ROW("detailedRow");
-
-	private String name;
-
-	private StyleName(String name) {
-
-		this.name = name;
-	}
-
-	public String getName() {
-
-		return name;
+		return infoRequest;
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/data/ValidationData.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/data/ValidationData.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.validation.noark53.provider;
+package com.documaster.validator.validation.noark53.provider.data;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -23,34 +23,22 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "rule")
-public class ValidationRule {
+@XmlRootElement(name = "queries")
+public class ValidationData extends Data {
 
-	@XmlElement(required = true, name = "title")
-	protected String title;
+	@XmlElement(name = "warnings")
+	private String warningsRequest;
 
-	@XmlElement(required = true, name = "group")
-	protected ValidationGroup group;
+	@XmlElement(name = "errors")
+	private String errorsRequest;
 
-	@XmlElement(required = true, name = "queries")
-	protected ValidationData data;
+	public String getWarningsRequest() {
 
-	public ValidationRule() {
-
+		return warningsRequest;
 	}
 
-	public String getTitle() {
+	public String getErrorsRequest() {
 
-		return title;
-	}
-
-	public ValidationGroup getGroup() {
-
-		return group;
-	}
-
-	public ValidationData getData() {
-
-		return data;
+		return errorsRequest;
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/rules/Check.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/rules/Check.java
@@ -15,45 +15,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.reporting.excel;
+package com.documaster.validator.validation.noark53.provider.rules;
 
-public enum StyleName {
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
-	LINK("link"),
+import com.documaster.validator.validation.noark53.provider.data.Data;
 
-	GROUP("summaryGroup"),
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "check")
+public class Check extends Rule {
 
-	RESULT_TITLE("summaryTitle"),
+	@XmlElement(required = true, name = "queries")
+	protected Data data;
 
-	RESULT_SUCCESS("summarySuccess"),
+	public Data getData() {
 
-	RESULT_WARNING("summaryWarning"),
-
-	RESULT_FAILURE("summaryFailure"),
-
-	RESULT_TITLE_SUCCESS("detailedTitleSuccess"),
-
-	RESULT_TITLE_WARNING("detailedTitleWarning"),
-
-	RESULT_TITLE_FAILURE("detailedTitleError"),
-
-	RESULT_DESCRIPTION("detailedDescription"),
-
-	RESULT_TYPE("detailedType"),
-
-	RESULT_HEADER_ROW("detailedHeaderRow"),
-
-	RESULT_ROW("detailedRow");
-
-	private String name;
-
-	private StyleName(String name) {
-
-		this.name = name;
-	}
-
-	public String getName() {
-
-		return name;
+		return data;
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/rules/Rule.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/rules/Rule.java
@@ -1,0 +1,59 @@
+/**
+ * Noark Extraction Validator
+ * Copyright (C) 2017, Documaster AS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.documaster.validator.validation.noark53.provider.rules;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import com.documaster.validator.validation.noark53.provider.ValidationGroup;
+import org.apache.commons.lang.StringUtils;
+
+public class Rule {
+
+	@XmlAttribute(required = true, name = "id")
+	protected String id;
+
+	@XmlElement(required = true, name = "title")
+	protected String title;
+
+	@XmlElement(required = true, name = "description")
+	protected String description;
+
+	@XmlElement(required = true, name = "group")
+	protected ValidationGroup group;
+
+	public String getId() {
+
+		return id;
+	}
+
+	public String getTitle() {
+
+		return title;
+	}
+
+	public String getDescription() {
+
+		return StringUtils.trimToEmpty(description).replaceAll("\\s+", " ");
+	}
+
+	public ValidationGroup getGroup() {
+
+		return group;
+	}
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/rules/Test.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/rules/Test.java
@@ -1,6 +1,6 @@
 /**
  * Noark Extraction Validator
- * Copyright (C) 2016, Documaster AS
+ * Copyright (C) 2017, Documaster AS
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -15,42 +15,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.documaster.validator.validation.noark53.provider;
+package com.documaster.validator.validation.noark53.provider.rules;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.documaster.validator.validation.noark53.provider.data.ValidationData;
+
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "queries")
-public class ValidationData {
+@XmlRootElement(name = "test")
+public class Test extends Rule {
 
-	@XmlElement(required = true, name = "info")
-	private String informationRequest;
+	@XmlElement(required = true, name = "queries")
+	protected ValidationData data;
 
-	@XmlElement(name = "warnings")
-	private String warningsRequest;
+	public ValidationData getData() {
 
-	@XmlElement(name = "errors")
-	private String errorsRequest;
-
-	public ValidationData() {
-
-	}
-
-	public String getInformationRequest() {
-
-		return informationRequest;
-	}
-
-	public String getWarningsRequest() {
-
-		return warningsRequest;
-	}
-
-	public String getErrorsRequest() {
-
-		return errorsRequest;
+		return data;
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XMLValidator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XMLValidator.java
@@ -22,8 +22,9 @@ import java.util.List;
 
 import com.documaster.validator.storage.model.BaseItem;
 import com.documaster.validator.validation.collector.ValidationCollector;
-import com.documaster.validator.validation.noark53.provider.ValidationGroup;
+import com.documaster.validator.validation.collector.ValidationResult;
 import com.documaster.validator.validation.noark53.model.Noark53PackageEntity;
+import com.documaster.validator.validation.noark53.provider.ValidationGroup;
 import com.documaster.validator.validation.utils.DefaultXMLHandler;
 import com.documaster.validator.validation.utils.SchemaValidator;
 import com.documaster.validator.validation.utils.WellFormedXmlValidator;
@@ -38,8 +39,10 @@ public class XMLValidator {
 
 		LOGGER.info("Validating XML File {} ...", entity.getXmlFile());
 
-		ValidationCollector.ValidationResult result = new ValidationCollector.ValidationResult(
-				entity.getXmlFileName() + " integrity", ValidationGroup.COMMON);
+		ValidationResult result = new ValidationResult(
+				ValidationGroup.PACKAGE.getNextGroupId(), entity.getXmlFileName() + " integrity",
+				"Tests whether the XML file 1) exists, 2) is valid XML, and 3) complies with the Noark schemas",
+				ValidationGroup.PACKAGE.getName());
 
 		boolean exists = validateExistence(entity.getXmlFile(), result);
 		boolean isWellFormed = validateIntegrity(entity.getXmlFile(), result);
@@ -52,7 +55,7 @@ public class XMLValidator {
 		return exists && isWellFormed && (compliesWithNoarkSchemas || ignoreNonComplianceToSchema);
 	}
 
-	private static boolean validateExistence(File xmlFile, ValidationCollector.ValidationResult result) {
+	private static boolean validateExistence(File xmlFile, ValidationResult result) {
 
 		if (!xmlFile.isFile()) {
 			result.addError(new BaseItem().add("Error", "Missing file: " + xmlFile.getName()));
@@ -63,7 +66,7 @@ public class XMLValidator {
 		}
 	}
 
-	private static boolean validateIntegrity(File xmlFile, ValidationCollector.ValidationResult result) {
+	private static boolean validateIntegrity(File xmlFile, ValidationResult result) {
 
 		WellFormedXmlValidator xmlIntegrityValidator = new WellFormedXmlValidator<>(new DefaultXMLHandler());
 
@@ -76,8 +79,7 @@ public class XMLValidator {
 		}
 	}
 
-	private static boolean validateAgainstPackageSchemas(
-			File xmlFile, ValidationCollector.ValidationResult result, List<File> xsdSchemas) {
+	private static boolean validateAgainstPackageSchemas(File xmlFile, ValidationResult result, List<File> xsdSchemas) {
 
 		SchemaValidator schemaValidator = new SchemaValidator<>(new NoarkXMLHandler(NoarkXMLHandler.Schema.PACKAGE));
 
@@ -91,8 +93,7 @@ public class XMLValidator {
 		}
 	}
 
-	private static boolean validateAgainstNoarkSchemas(
-			File xmlFile, ValidationCollector.ValidationResult result, List<File> xsdSchemas) {
+	private static boolean validateAgainstNoarkSchemas(File xmlFile, ValidationResult result, List<File> xsdSchemas) {
 
 		SchemaValidator schemaValidator = new SchemaValidator<>(new NoarkXMLHandler(NoarkXMLHandler.Schema.NOARK));
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XSDValidator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XSDValidator.java
@@ -21,6 +21,7 @@ import java.io.File;
 
 import com.documaster.validator.storage.model.BaseItem;
 import com.documaster.validator.validation.collector.ValidationCollector;
+import com.documaster.validator.validation.collector.ValidationResult;
 import com.documaster.validator.validation.noark53.provider.ValidationGroup;
 import com.documaster.validator.validation.utils.ChecksumCalculator;
 import com.documaster.validator.validation.utils.DefaultXMLHandler;
@@ -36,8 +37,11 @@ public class XSDValidator {
 
 		LOGGER.info("Validating XSD File {} ...", xsdFile);
 
-		ValidationCollector.ValidationResult result = new ValidationCollector.ValidationResult(
-				xsdFile.getName() + " integrity", ValidationGroup.COMMON);
+		ValidationResult result = new ValidationResult(
+				ValidationGroup.PACKAGE.getNextGroupId(), xsdFile.getName() + " integrity",
+				"Tests whether the XSD schema 1) exists, 2) is valid XML, and 3) its checksum "
+						+ "matches the checksum of its Noark counterpart",
+				ValidationGroup.PACKAGE.getName());
 
 		boolean exists = validateExistence(xsdFile, result);
 		boolean isWellFormed = validateIntegrity(xsdFile, result);
@@ -48,7 +52,7 @@ public class XSDValidator {
 		return exists && isWellFormed && checksumMatches;
 	}
 
-	private static boolean validateExistence(File xsdFile, ValidationCollector.ValidationResult result) {
+	private static boolean validateExistence(File xsdFile, ValidationResult result) {
 
 		if (!xsdFile.isFile()) {
 			result.addError(new BaseItem().add("Error", "Missing file: " + xsdFile.getName()));
@@ -59,7 +63,7 @@ public class XSDValidator {
 		}
 	}
 
-	private static boolean validateIntegrity(File xsdFile, ValidationCollector.ValidationResult result) {
+	private static boolean validateIntegrity(File xsdFile, ValidationResult result) {
 
 		WellFormedXmlValidator xmlIntegrityValidator = new WellFormedXmlValidator<>(new DefaultXMLHandler());
 
@@ -72,8 +76,7 @@ public class XSDValidator {
 		}
 	}
 
-	private static boolean validateChecksum(
-			File xsdFile, ValidationCollector.ValidationResult result, String checksum) {
+	private static boolean validateChecksum(File xsdFile, ValidationResult result, String checksum) {
 
 		if (!xsdFile.isFile() || !checksum.equalsIgnoreCase(ChecksumCalculator.getFileSha256Checksum(xsdFile))) {
 			result.addWarning(

--- a/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xml
+++ b/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xml
@@ -22,9 +22,17 @@
     <!-- View the associated xsd for more information on the structure of the file. -->
     <!-- Note that there is a limitation on the possible values of the group element -->
 
-    <rule>
+    <!--
+    ============================================================================================================
+    ARKIVUTTREKK
+    ============================================================================================================
+    -->
+    <!-- Tests -->
+
+    <test id="AUT1">
         <title>arkivstruktur.xml checksum</title>
-        <group>common</group>
+        <description>Tests whether the checksum of arkivstruktur.xml matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -68,11 +76,12 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AUT2">
         <title>arkivstruktur.xsd checksum</title>
-        <group>common</group>
+        <description>Tests whether the checksum of arkivstruktur.xsd matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -116,11 +125,12 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>loependejournal.xml checksum</title>
-        <group>common</group>
+    <test id="AUT3">
+        <title>loependeJournal.xml checksum</title>
+        <description>Tests whether the checksum of loependeJournal.xml matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -160,15 +170,16 @@
                         FROM addml.property
                         WHERE name = 'loependeJournal.xml'
                     ) detected
-                    WHERE detected.value <> arkivuttrekk_checksum OR arkivuttrekk_checksum IS NULL OR detected.value IS NULL;
+                    WHERE detected.value <> arkivuttrekk_checksum;
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>loependejournal.xsd checksum</title>
-        <group>common</group>
+    <test id="AUT4">
+        <title>loependeJournal.xsd checksum</title>
+        <description>Tests whether the checksum of loependeJournal.xsd matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -208,15 +219,16 @@
                         FROM addml.property
                         WHERE name = 'loependeJournal.xsd'
                     ) detected
-                    WHERE detected.value <> arkivuttrekk_checksum OR arkivuttrekk_checksum IS NULL OR detected.value IS NULL;
+                    WHERE detected.value <> arkivuttrekk_checksum AND arkivuttrekk_checksum IS NOT NULL AND detected.value IS NOT NULL;
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AUT5">
         <title>offentligJournal.xml checksum</title>
-        <group>common</group>
+        <description>Tests whether the checksum of offentligJournal.xml matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -256,15 +268,16 @@
                         FROM addml.property
                         WHERE name = 'offentligJournal.xml'
                     ) detected
-                    WHERE detected.value <> arkivuttrekk_checksum OR arkivuttrekk_checksum IS NULL OR detected.value IS NULL;
+                    WHERE detected.value <> arkivuttrekk_checksum;
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AUT6">
         <title>offentligJournal.xsd checksum</title>
-        <group>common</group>
+        <description>Tests whether the checksum of offentligJournal.xsd matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -304,15 +317,16 @@
                         FROM addml.property
                         WHERE name = 'offentligJournal.xsd'
                     ) detected
-                    WHERE detected.value <> arkivuttrekk_checksum OR arkivuttrekk_checksum IS NULL OR detected.value IS NULL;
+                    WHERE detected.value <> arkivuttrekk_checksum AND arkivuttrekk_checksum IS NOT NULL AND detected.value IS NOT NULL;
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AUT7">
         <title>endringslogg.xml checksum</title>
-        <group>common</group>
+        <description>Tests whether the checksum of endringslogg.xml matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -356,11 +370,12 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AUT8">
         <title>endringslogg.xsd checksum</title>
-        <group>common</group>
+        <description>Tests whether the checksum of endringslogg.xsd matches the one specified in arkivuttrekk.xml.</description>
+        <group>arkivuttrekk</group>
         <queries>
             <info>
                 <![CDATA[
@@ -404,10 +419,507 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Extraction-wide systemid field uniqueness</title>
+    <!--
+    ============================================================================================================
+    ARKIVSTRUKTUR
+    ============================================================================================================
+    -->
+    <!-- Checks -->
+    <check id="ASC1">
+        <title>Fonds</title>
+        <description>Number of fonds</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT
+                        a.systemid system_id,
+                        a.tittel title,
+                        (_ref_arkiv IS NULL) is_root,
+                        (COUNT(*) - 1) children_count
+                    FROM arkivstruktur.arkiv a
+                    LEFT JOIN arkivstruktur.arkiv b ON a._id = b._parent_id
+                    GROUP BY system_id, title, is_root
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC2">
+        <title>Classification systems</title>
+        <description>Number of classification systems grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT s.systemid series_system_id, COUNT(*) ks_count
+                    FROM arkivstruktur.arkivdel s
+                    JOIN arkivstruktur.klassifikasjonssystem ks ON ks._parent_id = s._id
+                    GROUP BY s.systemid
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC3">
+        <title>Classes</title>
+        <description>Number of classes grouped by classification system</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT ks.systemid ks_system_id, parent.systemid parent_system_id, COUNT(*) number_of_classes
+                    FROM arkivstruktur.klasse k
+                    LEFT JOIN arkivstruktur.klasse parent ON parent.systemid = k._ref_klasse
+                    LEFT JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
+                    GROUP BY ks.systemid, parent.systemid;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC4">
+        <title>Classes without subclasses, files, or records</title>
+        <description>Number of classes without children of any type, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT ks._ref_arkivdel series_system_id, COUNT(DISTINCT(k.systemid)) classes_without_children
+                    FROM arkivstruktur.klasse k
+                    JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
+                    WHERE k.systemid NOT IN (SELECT _ref_klasse FROM arkivstruktur.klasse WHERE _ref_klasse IS NOT NULL GROUP BY _ref_klasse)
+                        AND k.systemid NOT IN (SELECT _ref_klasse FROM arkivstruktur.mappe WHERE _ref_klasse IS NOT NULL)
+                        AND k.systemid NOT IN (SELECT _ref_klasse FROM arkivstruktur.registrering WHERE _ref_klasse IS NOT NULL GROUP BY _ref_klasse)
+                    GROUP BY ks._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC5">
+        <title>Files with classes</title>
+        <description>Number of files grouped by class and series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT f._ref_arkivdel series_system_id, f._ref_klasse class_system_id, COUNT(*) number_of_files
+                    FROM arkivstruktur.mappe f
+                    GROUP BY f._ref_arkivdel, f._ref_klasse;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC6">
+        <title>Files without subfiles or records</title>
+        <description>Number of files without children of any type, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT f._ref_arkivdel series_system_id, COUNT(*) empty_file_count
+                    FROM arkivstruktur.mappe f
+                    WHERE f.systemid NOT IN (SELECT _ref_mappe FROM arkivstruktur.mappe WHERE _ref_mappe IS NOT NULL GROUP BY _ref_mappe)
+                        AND f.systemid NOT IN (SELECT _ref_mappe FROM arkivstruktur.registrering WHERE _ref_mappe IS NOT NULL GROUP BY _ref_mappe)
+                    GROUP BY f._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC7">
+        <title>Registry entries without a main document</title>
+        <description>Number of registry entries without a main document, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, r._dtype registry_entry_type, COUNT(*) registry_entries_without_a_main_document
+                    FROM arkivstruktur.registrering r
+                    WHERE r._dtype = 'journalpost' AND r.systemid NOT IN (
+                        SELECT _ref_registrering
+                        FROM arkivstruktur.dokumentbeskrivelse
+                        WHERE tilknyttetregistreringsom = 'Hoveddokument' AND _ref_registrering IS NOT NULL
+                        GROUP BY _ref_registrering
+                    )
+                    GROUP BY r._ref_arkivdel, r._dtype;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC8">
+        <title>Records with classes</title>
+        <description>Number of records with classes, grouped by class and series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, r._ref_klasse class_system_id, COUNT(*) number_of_records
+                    FROM arkivstruktur.registrering r
+                    WHERE r._ref_mappe IS NULL
+                    GROUP BY r._ref_arkivdel, r._ref_klasse;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC9">
+        <title>Records without document descriptions</title>
+        <description>Number of records without document descriptions, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, COUNT(*) records_without_documents
+                    FROM arkivstruktur.registrering r
+                    WHERE r.systemid NOT IN (SELECT _ref_registrering FROM arkivstruktur.dokumentbeskrivelse WHERE _ref_registrering IS NOT NULL GROUP BY _ref_registrering)
+                    GROUP BY r._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC10">
+        <title>Document descriptions</title>
+        <description>Number of document descriptions grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, count(*) number_of_document_description
+                    FROM arkivstruktur.dokumentbeskrivelse d
+                    JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
+                    GROUP BY r._ref_arkivdel
+
+                    UNION ALL
+
+                    SELECT 'total', count(*)
+                    FROM arkivstruktur.dokumentbeskrivelse;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC11">
+        <title>Document descriptions without document objects</title>
+        <description>Number of document descriptions without document objects, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, COUNT(*) document_descriptions_without_document_objects
+                    FROM arkivstruktur.dokumentbeskrivelse d
+                    JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
+                    WHERE d.systemid NOT IN (
+                        SELECT _ref_dokumentbeskrivelse
+                        FROM arkivstruktur.dokumentobjekt
+                        WHERE _ref_dokumentbeskrivelse IS NOT NULL
+                        GROUP BY _ref_dokumentbeskrivelse
+                    )
+                    GROUP BY r._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC12">
+        <title>Document objects</title>
+        <description>Number of document objects grouped by series and parent (document description or record)</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT
+                        r._ref_arkivdel series_system_id,
+                        COUNT(*) document_objects,
+                        (d._ref_dokumentbeskrivelse IS NOT NULL) in_document_description,
+                        (d._ref_dokumentbeskrivelse IS NULL) in_record
+                    FROM arkivstruktur.dokumentobjekt d
+                    LEFT JOIN arkivstruktur.dokumentbeskrivelse dd ON dd._id = d._parent_id
+                    LEFT JOIN arkivstruktur.registrering r ON r._id = d._parent_id
+                    GROUP BY series_system_id, in_document_description, in_record
+
+                    UNION ALL
+
+                    SELECT 'total', count(*), TRUE in_document_description, TRUE in_record
+                    FROM arkivstruktur.dokumentobjekt;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC13">
+        <title>Case parties</title>
+        <description>Number of case parties grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT f._ref_arkivdel series_system_id, COUNT(*) number_of_case_parties
+                    FROM arkivstruktur.sakspart cp
+                    JOIN arkivstruktur.mappe f ON f.systemid = cp._ref_mappe
+                    GROUP BY f._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC14">
+        <title>Notes</title>
+        <description>Number of notes associated with files, records, or document descriptions, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT s.systemid series_system_id,
+                        COALESCE(f.val, 0) number_of_file_notes,
+                        COALESCE(r.val, 0) number_of_record_notes,
+                        COALESCE(d.val, 0) number_of_document_notes
+                    FROM arkivstruktur.arkivdel s
+                    LEFT JOIN
+                    (
+                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.merknad n
+                        JOIN arkivstruktur.mappe f ON f.systemid = n._ref_mappe
+                        GROUP BY f._ref_arkivdel
+                    ) f ON f.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.merknad n
+                        JOIN arkivstruktur.registrering r ON r.systemid = n._ref_registrering
+                        GROUP BY r._ref_arkivdel
+                    ) r ON r.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.merknad n
+                        JOIN arkivstruktur.dokumentbeskrivelse d ON d.systemid = n._ref_dokumentbeskrivelse
+                        JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
+                        GROUP BY r._ref_arkivdel
+                    ) d ON d.series_system_id = s.systemid;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC15">
+        <title>Cross references</title>
+        <description>Number of cross references associated with classes, files, or records, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT s.systemid series_system_id,
+                        COALESCE(k.val, 0) number_of_klass_cross_references,
+                        COALESCE(f.val, 0) number_of_file_cross_references,
+                        COALESCE(r.val, 0) number_of_record_cross_references
+                    FROM arkivstruktur.arkivdel s
+                    LEFT JOIN
+                    (
+                        SELECT ks._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.kryssreferanse cr
+                        JOIN arkivstruktur.klasse k ON k.systemid = cr._ref_klasse
+                        JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
+                        GROUP BY ks._ref_arkivdel
+                    ) k ON k.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.kryssreferanse cr
+                        JOIN arkivstruktur.mappe f ON f.systemid =  cr._ref_mappe
+                        GROUP BY f._ref_arkivdel
+                    ) f ON f.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.kryssreferanse cr
+                        JOIN arkivstruktur.registrering r ON r.systemid = cr._ref_registrering
+                        GROUP BY r._ref_arkivdel
+                    ) r ON r.series_system_id = s.systemid;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC16">
+        <title>Precedents</title>
+        <description>Number of precedents associated with files or records, grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT s.systemid series_system_id,
+                        COALESCE(f.val, 0) number_of_file_precedents,
+                        COALESCE(r.val, 0) number_of_record_precedents
+                    FROM arkivstruktur.arkivdel s
+                    LEFT JOIN
+                    (
+                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.presedens p
+                        JOIN arkivstruktur.mappe f ON f.systemid = p._ref_mappe
+                        GROUP BY f._ref_arkivdel
+                    ) f ON f.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.presedens p
+                        JOIN arkivstruktur.registrering r ON r.systemid = p._ref_registrering
+                        GROUP BY r._ref_arkivdel
+                    ) r ON r.series_system_id = s.systemid;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC17">
+        <title>Sign-offs</title>
+        <description>Number of sign-offs grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, COUNT(*) number_of_sign_offs
+                    FROM arkivstruktur.registrering r
+                    WHERE r._dtype = 'journalpost' AND r.systemid in (SELECT _ref_registrering FROM arkivstruktur.avskrivning WHERE _ref_registrering IS NOT NULL GROUP BY _ref_registrering)
+                    GROUP BY r._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC18">
+        <title>Document flows</title>
+        <description>Number of document flows grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, COUNT(*) number_of_document_flows
+                    FROM arkivstruktur.registrering r
+                    WHERE r._dtype = 'journalpost' AND r.systemid in (SELECT _ref_registrering FROM arkivstruktur.dokumentflyt WHERE _ref_registrering IS NOT NULL GROUP BY _ref_registrering)
+                    GROUP BY r._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC19">
+        <title>Gradings</title>
+        <description>
+            Number of gradings associated with series, classes,
+            files, records, or document descriptions
+        </description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT s.systemid series_system_id,
+                        COALESCE(series.val, 0) number_of_series_gradings,
+                        COALESCE(class.val, 0) number_of_class_gradings,
+                        COALESCE(file.val, 0) number_of_file_gradings,
+                        COALESCE(item.val, 0) number_of_record_gradings,
+                        COALESCE(document.val, 0) number_of_document_descriptions_gradings
+                    FROM arkivstruktur.arkivdel s
+                    LEFT JOIN
+                    (
+                        SELECT g._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.gradering g
+                        GROUP BY g._ref_arkivdel
+                    ) series ON series.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT ks._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.gradering g
+                        JOIN arkivstruktur.klasse k ON k.systemid = g._ref_klasse
+                        JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
+                        GROUP BY ks._ref_arkivdel
+                    ) class ON class.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.gradering g
+                        JOIN arkivstruktur.mappe f ON f.systemid = g._ref_mappe
+                        GROUP BY f._ref_arkivdel
+                    ) file ON file.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.gradering g
+                        JOIN arkivstruktur.registrering r ON r.systemid = g._ref_registrering
+                        GROUP BY r._ref_arkivdel
+                    ) item ON item.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.gradering g
+                        JOIN arkivstruktur.dokumentbeskrivelse d ON d.systemid = g._ref_dokumentbeskrivelse
+                        JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
+                        GROUP BY r._ref_arkivdel
+                    ) document ON document.series_system_id = s.systemid;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC20">
+        <title>Conversions</title>
+        <description>Number of conversions grouped by series</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT r._ref_arkivdel series_system_id, COUNT(*) number_of_conversions
+                    FROM arkivstruktur.konvertering k
+                    JOIN arkivstruktur.dokumentobjekt d ON k._parent_id = d._id
+                    JOIN arkivstruktur.dokumentbeskrivelse dd ON dd.systemid = d._ref_dokumentbeskrivelse
+                    JOIN arkivstruktur.registrering r ON r.systemid = dd._ref_registrering
+                    GROUP BY r._ref_arkivdel;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <check id="ASC21">
+        <title>Deletions (apart from disposals)</title>
+        <description>Number of deletions (apart from disposals)</description>
+        <group>arkivstruktur</group>
+        <queries>
+            <info>
+                <![CDATA[
+                    SELECT s.systemid series_system_id,
+                        COALESCE(series.val, 0) number_of_series_deletions_apart_from_disposals,
+                        COALESCE(document.val, 0) number_of_document_descriptions_deletions_apart_from_disposals
+                    FROM arkivstruktur.arkivdel s
+                    LEFT JOIN
+                    (
+                        SELECT sl._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.sletting sl
+                        GROUP BY sl._ref_arkivdel
+                    ) series ON series.series_system_id = s.systemid
+                    LEFT JOIN
+                    (
+                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
+                        FROM arkivstruktur.sletting sl
+                        JOIN arkivstruktur.dokumentbeskrivelse d ON d.systemid = sl._ref_dokumentbeskrivelse
+                        JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
+                        GROUP BY r._ref_arkivdel
+                    ) document ON document.series_system_id = s.systemid;
+                ]]>
+            </info>
+        </queries>
+    </check>
+
+    <!-- Tests -->
+
+    <test id="AST1">
+        <title>Extraction-wide systemID uniqueness</title>
+        <description>Tests whether the same systemID has been used for more than one object in the archive.</description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -470,29 +982,14 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Fonds count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT
-                        a.systemid system_id,
-                        a.tittel title,
-                        (_ref_arkiv IS NULL) is_root,
-                        (COUNT(*) - 1) children_count
-                    FROM arkivstruktur.arkiv a
-                    LEFT JOIN arkivstruktur.arkiv b ON a._id = b._parent_id
-                    GROUP BY system_id, title, is_root
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Series count</title>
+    <test id="AST2">
+        <title>Series</title>
+        <description>
+            Provides information about the number of series in the archive,
+            and tests whether a fonds without any series exists.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -513,10 +1010,14 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AST3">
         <title>Fonds period containment</title>
+        <description>
+            Tests whether the created and finalized dates of all fonds
+            are within the archival period specified in arkivuttrekk.xml.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -597,10 +1098,14 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AST4">
         <title>Series period containment</title>
+        <description>
+            Tests whether the created and finalized dates of all series
+            are within the archival period specified in arkivuttrekk.xml.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -680,10 +1185,15 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AST5">
         <title>Series status</title>
+        <description>
+            Tests whether non-finalized series exist in the archive.
+            A series is considered non-finalized if a finalized date or
+            a finalizing party is not specified, or if the series status is not 'Avsluttet periode'.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -711,59 +1221,14 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Classification Systems count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT s.systemid series_system_id, COUNT(*) ks_count
-                    FROM arkivstruktur.arkivdel s
-                    JOIN arkivstruktur.klassifikasjonssystem ks ON ks._parent_id = s._id
-                    GROUP BY s.systemid
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Class count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT ks.systemid ks_system_id, parent.systemid parent_system_id, COUNT(*) number_of_classes
-                    FROM arkivstruktur.klasse k
-                    LEFT JOIN arkivstruktur.klasse parent ON parent.systemid = k._ref_klasse
-                    LEFT JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
-                    GROUP BY ks.systemid, parent.systemid;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Classes without subclasses, files, or records</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT ks._ref_arkivdel series_system_id, COUNT(DISTINCT(k.systemid)) classes_without_children
-                    FROM arkivstruktur.klasse k
-                    JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
-                    WHERE k.systemid NOT IN (SELECT _ref_klasse FROM arkivstruktur.klasse WHERE _ref_klasse IS NOT NULL GROUP BY _ref_klasse)
-                        AND k.systemid NOT IN (SELECT _ref_klasse FROM arkivstruktur.mappe WHERE _ref_klasse IS NOT NULL)
-                        AND k.systemid NOT IN (SELECT _ref_klasse FROM arkivstruktur.registrering WHERE _ref_klasse IS NOT NULL GROUP BY _ref_klasse)
-                    GROUP BY ks._ref_arkivdel;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
+    <test id="AST6">
         <title>File count</title>
+        <description>
+            Provides information about the number of files per series and
+            tests whether the corresponding number specified in arkivuttrekk.xml is correct.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -802,10 +1267,14 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AST7">
         <title>File period containment</title>
+        <description>
+            Tests whether the created and finalized dates of all files
+            are within the archival period specified in arkivuttrekk.xml.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -894,10 +1363,15 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Files within leaf classes</title>
+    <test id="AST8">
+        <title>Files in leaf classes</title>
+        <description>
+            Provides information about the number of files per series and class,
+            and tests whether any file belongs to a class which has other classes
+            as children (i.e. the file has a class sibling).
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -945,40 +1419,15 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Files within classes</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT f._ref_arkivdel series_system_id, f._ref_klasse class_system_id, COUNT(*) number_of_files
-                    FROM arkivstruktur.mappe f
-                    GROUP BY f._ref_arkivdel, f._ref_klasse;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Files without subfolders or records.</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT f._ref_arkivdel series_system_id, COUNT(*) empty_file_count
-                    FROM arkivstruktur.mappe f
-                    WHERE f.systemid NOT IN (SELECT _ref_mappe FROM arkivstruktur.mappe WHERE _ref_mappe IS NOT NULL GROUP BY _ref_mappe)
-                        AND f.systemid NOT IN (SELECT _ref_mappe FROM arkivstruktur.registrering WHERE _ref_mappe IS NOT NULL GROUP BY _ref_mappe)
-                    GROUP BY f._ref_arkivdel;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
+    <test id="AST9">
         <title>File status</title>
+        <description>
+            Tests whether non-finalized files exists in the archive.
+            A file is considered non-finalized if a finalized date or
+            a finalizing party is not specified, or if the file status is not 'Avsluttet'.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1014,10 +1463,14 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Record count</title>
+    <test id="AST10">
+        <title>Records</title>
+        <description>
+            Provides information about the number of records per series
+            and tests whether the corresponding number specified in arkivuttrekk.xml is correct.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1056,30 +1509,14 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Registry entries without a main document</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, r._dtype registry_entry_type, COUNT(*) registry_entries_without_a_main_document
-                    FROM arkivstruktur.registrering r
-                    WHERE r._dtype = 'journalpost' AND r.systemid NOT IN (
-                        SELECT _ref_registrering
-                        FROM arkivstruktur.dokumentbeskrivelse
-                        WHERE tilknyttetregistreringsom = 'Hoveddokument' AND _ref_registrering IS NOT NULL
-                        GROUP BY _ref_registrering
-                    )
-                    GROUP BY r._ref_arkivdel, r._dtype;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
+    <test id="AST11">
         <title>Record period containment</title>
+        <description>
+            Tests whether the created and finalized dates of all records are
+            within the archival period specified in arkivuttrekk.xml.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1168,10 +1605,15 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Records within leaf classes</title>
+    <test id="AST12">
+        <title>Records in leaf classes</title>
+        <description>
+            Provides information about the number of records per series and class,
+            and tests whether any record belongs to a class which has other
+            classes as children (i.e. the record has a class sibling).
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1219,40 +1661,15 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Records within classes</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, r._ref_klasse class_system_id, COUNT(*) number_of_files
-                    FROM arkivstruktur.registrering r
-                    WHERE r._ref_mappe IS NULL
-                    GROUP BY r._ref_arkivdel, r._ref_klasse;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Records without document descriptions</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, COUNT(*) records_without_documents
-                    FROM arkivstruktur.registrering r
-                    WHERE r.systemid NOT IN (SELECT _ref_registrering FROM arkivstruktur.dokumentbeskrivelse WHERE _ref_registrering IS NOT NULL GROUP BY _ref_registrering)
-                    GROUP BY r._ref_arkivdel;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
+    <test id="AST13">
         <title>Record status</title>
+        <description>
+            Tests whether non-finalized records exist in the archive.
+            A record is considered non-finalized if a finalized date or a
+            finalizing party is not specified, or if the record status is not 'Arkivert' or 'Utgår'.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1289,51 +1706,16 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Document Description count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, count(*) number_of_document_description
-                    FROM arkivstruktur.dokumentbeskrivelse d
-                    JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
-                    GROUP BY r._ref_arkivdel
-
-                    UNION ALL
-
-                    SELECT 'total', count(*)
-                    FROM arkivstruktur.dokumentbeskrivelse;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Document Descriptions without Document Objects</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, COUNT(*) document_descriptions_without_document_objects
-                    FROM arkivstruktur.dokumentbeskrivelse d
-                    JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
-                    WHERE d.systemid NOT IN (
-                        SELECT _ref_dokumentbeskrivelse
-                        FROM arkivstruktur.dokumentobjekt
-                        WHERE _ref_dokumentbeskrivelse IS NOT NULL
-                        GROUP BY _ref_dokumentbeskrivelse
-                    )
-                    GROUP BY r._ref_arkivdel;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Document Description status</title>
+    <test id="AST14">
+        <title>Document description status</title>
+        <description>
+            Tests whether non-finalized document descriptions exist in the archive.
+            A document description is considered non-finalized if a finalized date
+            or a finalizing party is not specified, or if the document description
+            status is not 'Dokumentet er ferdigstilt'.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1367,10 +1749,14 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Document Description period containment</title>
+    <test id="AST15">
+        <title>Document description period containment</title>
+        <description>
+            Tests whether the created and finalized dates of all document descriptions
+            are within the archival period specified in arkivuttrekk.xml.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1436,35 +1822,14 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Document Object count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT
-                        r._ref_arkivdel series_system_id,
-                        COUNT(*) document_objects,
-                        (d._ref_dokumentbeskrivelse IS NOT NULL) in_document_description,
-                        (d._ref_dokumentbeskrivelse IS NULL) in_record
-                    FROM arkivstruktur.dokumentobjekt d
-                    LEFT JOIN arkivstruktur.dokumentbeskrivelse dd ON dd._id = d._parent_id
-                    LEFT JOIN arkivstruktur.registrering r ON r._id = d._parent_id
-                    GROUP BY series_system_id, in_document_description, in_record
-
-                    UNION ALL
-
-                    SELECT 'total', count(*), TRUE in_document_description, TRUE in_record
-                    FROM arkivstruktur.dokumentobjekt;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
+    <test id="AST16">
         <title>Document object checksums</title>
+        <description>
+            Tests whether the document object checksums specified in arkivstruktur.xml
+            match the ones that the validator calculated using the SHA256 algorithm.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1482,10 +1847,11 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="AST17">
         <title>Document object file types</title>
+        <description>Tests whether all document objects are valid PDF/A1B documents.</description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1503,130 +1869,14 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Case Party count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT f._ref_arkivdel series_system_id, COUNT(*) number_of_case_parties
-                    FROM arkivstruktur.sakspart cp
-                    JOIN arkivstruktur.mappe f ON f.systemid = cp._ref_mappe
-                    GROUP BY f._ref_arkivdel;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Note count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT s.systemid series_system_id,
-                        COALESCE(f.val, 0) number_of_file_notes,
-                        COALESCE(r.val, 0) number_of_record_notes,
-                        COALESCE(d.val, 0) number_of_document_notes
-                    FROM arkivstruktur.arkivdel s
-                    LEFT JOIN
-                    (
-                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.merknad n
-                        JOIN arkivstruktur.mappe f ON f.systemid = n._ref_mappe
-                        GROUP BY f._ref_arkivdel
-                    ) f ON f.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.merknad n
-                        JOIN arkivstruktur.registrering r ON r.systemid = n._ref_registrering
-                        GROUP BY r._ref_arkivdel
-                    ) r ON r.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.merknad n
-                        JOIN arkivstruktur.dokumentbeskrivelse d ON d.systemid = n._ref_dokumentbeskrivelse
-                        JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
-                        GROUP BY r._ref_arkivdel
-                    ) d ON d.series_system_id = s.systemid;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Cross reference count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT s.systemid series_system_id,
-                        COALESCE(k.val, 0) number_of_klass_cross_references,
-                        COALESCE(f.val, 0) number_of_file_cross_references,
-                        COALESCE(r.val, 0) number_of_record_cross_references
-                    FROM arkivstruktur.arkivdel s
-                    LEFT JOIN
-                    (
-                        SELECT ks._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.kryssreferanse cr
-                        JOIN arkivstruktur.klasse k ON k.systemid = cr._ref_klasse
-                        JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
-                        GROUP BY ks._ref_arkivdel
-                    ) k ON k.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.kryssreferanse cr
-                        JOIN arkivstruktur.mappe f ON f.systemid =  cr._ref_mappe
-                        GROUP BY f._ref_arkivdel
-                    ) f ON f.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.kryssreferanse cr
-                        JOIN arkivstruktur.registrering r ON r.systemid = cr._ref_registrering
-                        GROUP BY r._ref_arkivdel
-                    ) r ON r.series_system_id = s.systemid;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Precedent count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT s.systemid series_system_id,
-                        COALESCE(f.val, 0) number_of_file_precedents,
-                        COALESCE(r.val, 0) number_of_record_precedents
-                    FROM arkivstruktur.arkivdel s
-                    LEFT JOIN
-                    (
-                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.presedens p
-                        JOIN arkivstruktur.mappe f ON f.systemid = p._ref_mappe
-                        GROUP BY f._ref_arkivdel
-                    ) f ON f.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.presedens p
-                        JOIN arkivstruktur.registrering r ON r.systemid = p._ref_registrering
-                        GROUP BY r._ref_arkivdel
-                    ) r ON r.series_system_id = s.systemid;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Correspondence Party count</title>
+    <test id="AST18">
+        <title>Correspondence parties</title>
+        <description>
+            Provides information about the number of correspondence parties grouped
+            by series and tests whether any registry entries without correspondence parties exist.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1648,40 +1898,15 @@
                 ]]>
             </errors>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Sign Off count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, COUNT(*) number_of_sign_offs
-                    FROM arkivstruktur.registrering r
-                    WHERE r._dtype = 'journalpost' AND r.systemid in (SELECT _ref_registrering FROM arkivstruktur.avskrivning WHERE _ref_registrering IS NOT NULL GROUP BY _ref_registrering)
-                    GROUP BY r._ref_arkivdel;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Document Flow count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, COUNT(*) number_of_document_flows
-                    FROM arkivstruktur.registrering r
-                    WHERE r._dtype = 'journalpost' AND r.systemid in (SELECT _ref_registrering FROM arkivstruktur.dokumentflyt WHERE _ref_registrering IS NOT NULL GROUP BY _ref_registrering)
-                    GROUP BY r._ref_arkivdel;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Screening count</title>
+    <test id="AST19">
+        <title>Screenings</title>
+        <description>
+            Provides information about the number of screened series, classes,
+            files, records, and document descriptions, and tests whether the corresponding
+            number in arkivuttrekk.xml (inneholderSkjermetInformasjon) is correct.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1796,64 +2021,15 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Grading count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT s.systemid series_system_id,
-                        COALESCE(series.val, 0) number_of_series_gradings,
-                        COALESCE(class.val, 0) number_of_class_gradings,
-                        COALESCE(file.val, 0) number_of_file_gradings,
-                        COALESCE(item.val, 0) number_of_record_gradings,
-                        COALESCE(document.val, 0) number_of_document_descriptions_gradings
-                    FROM arkivstruktur.arkivdel s
-                    LEFT JOIN
-                    (
-                        SELECT g._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.gradering g
-                        GROUP BY g._ref_arkivdel
-                    ) series ON series.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT ks._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.gradering g
-                        JOIN arkivstruktur.klasse k ON k.systemid = g._ref_klasse
-                        JOIN arkivstruktur.klassifikasjonssystem ks ON ks.systemid = k._ref_klassifikasjonssystem
-                        GROUP BY ks._ref_arkivdel
-                    ) class ON class.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT f._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.gradering g
-                        JOIN arkivstruktur.mappe f ON f.systemid = g._ref_mappe
-                        GROUP BY f._ref_arkivdel
-                    ) file ON file.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.gradering g
-                        JOIN arkivstruktur.registrering r ON r.systemid = g._ref_registrering
-                        GROUP BY r._ref_arkivdel
-                    ) item ON item.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.gradering g
-                        JOIN arkivstruktur.dokumentbeskrivelse d ON d.systemid = g._ref_dokumentbeskrivelse
-                        JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
-                        GROUP BY r._ref_arkivdel
-                    ) document ON document.series_system_id = s.systemid;
-                ]]>
-            </info>
-        </queries>
-    </rule>
-
-    <rule>
-        <title>Disposal decision count</title>
+    <test id="AST20">
+        <title>Disposal decisions</title>
+        <description>
+            Provides information about the number of disposal decisions related to series, classes,
+            files, records, and document descriptions, and tests whether the corresponding
+            number in arkivuttrekk.xml (inneholderDokumenterSomSkalKasseres) is correct.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -1968,10 +2144,15 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Disposal count</title>
+    <test id="AST21">
+        <title>Disposals</title>
+        <description>
+            Provides information about the number of disposals of series
+            and document descriptions, and tests whether the corresponding
+            number in arkivuttrekk.xml (omfatterDokumenterSomErKassert) is correct.
+        </description>
         <group>arkivstruktur</group>
         <queries>
             <info>
@@ -2036,56 +2217,37 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Conversion count</title>
-        <group>arkivstruktur</group>
+    <!--
+    ============================================================================================================
+    LOEPENDEJOURNAL
+    ============================================================================================================
+    -->
+    <!-- Checks -->
+
+    <check id="LJC1">
+        <title>Screened registry entries</title>
+        <description>Number of screened registry entries found in loependeJournal.xml</description>
+        <group>loependejournal</group>
         <queries>
             <info>
                 <![CDATA[
-                    SELECT r._ref_arkivdel series_system_id, COUNT(*) number_of_conversions
-                    FROM arkivstruktur.konvertering k
-                    JOIN arkivstruktur.dokumentobjekt d ON k._parent_id = d._id
-                    JOIN arkivstruktur.dokumentbeskrivelse dd ON dd.systemid = d._ref_dokumentbeskrivelse
-                    JOIN arkivstruktur.registrering r ON r.systemid = dd._ref_registrering
-                    GROUP BY r._ref_arkivdel;
+                    SELECT COUNT(tilgangsrestriksjon) screened_registry_entries
+                    FROM loependejournal.journalpost;
                 ]]>
             </info>
         </queries>
-    </rule>
+    </check>
 
-    <rule>
-        <title>Deletion apart from disposal count</title>
-        <group>arkivstruktur</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT s.systemid series_system_id,
-                        COALESCE(series.val, 0) number_of_series_deletions_apart_from_disposals,
-                        COALESCE(document.val, 0) number_of_document_descriptions_deletions_apart_from_disposals
-                    FROM arkivstruktur.arkivdel s
-                    LEFT JOIN
-                    (
-                        SELECT sl._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.sletting sl
-                        GROUP BY sl._ref_arkivdel
-                    ) series ON series.series_system_id = s.systemid
-                    LEFT JOIN
-                    (
-                        SELECT r._ref_arkivdel series_system_id, COUNT(*) val
-                        FROM arkivstruktur.sletting sl
-                        JOIN arkivstruktur.dokumentbeskrivelse d ON d.systemid = sl._ref_dokumentbeskrivelse
-                        JOIN arkivstruktur.registrering r ON r.systemid = d._ref_registrering
-                        GROUP BY r._ref_arkivdel
-                    ) document ON document.series_system_id = s.systemid;
-                ]]>
-            </info>
-        </queries>
-    </rule>
+    <!-- Tests -->
 
-    <rule>
-        <title>Registry Entry count</title>
+    <test id="LJT1">
+        <title>Registry entries</title>
+        <description>
+            Provides information about the number of registry entries found in loependeJournal.xml
+            and tests whether it matches the number of registry entries found in arkivstruktur.xml.
+        </description>
         <group>loependejournal</group>
         <queries>
             <info>
@@ -2153,10 +2315,15 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="LJT2">
         <title>Period containment of registry entries</title>
+        <description>
+            Tests whether the created and finalized dates of all registry entries in loependeJournal.xml
+            are within the archival period specified in arkivuttrekk.xml, and whether the same registry entries
+            (same systemIDs) can be found in arkivstruktur.xml.
+        </description>
         <group>loependejournal</group>
         <queries>
             <info>
@@ -2245,23 +2412,21 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Number of screened registry entries</title>
-        <group>loependejournal</group>
-        <queries>
-            <info>
-                <![CDATA[
-                    SELECT COUNT(tilgangsrestriksjon) screened_registry_entries
-                    FROM loependejournal.journalpost;
-                ]]>
-            </info>
-        </queries>
-    </rule>
+    <!--
+    ============================================================================================================
+    OFFENTLIGJOURNAL
+    ============================================================================================================
+    -->
+    <!-- Tests -->
 
-    <rule>
-        <title>Registry Entry count</title>
+    <test id="OJT1">
+        <title>Registry entries</title>
+        <description>
+            Provides information about the number of registry entries found in offentligJournal.xml
+            and tests whether it matches the number of registry entries found in arkivstruktur.xml.
+        </description>
         <group>offentligjournal</group>
         <queries>
             <info>
@@ -2329,10 +2494,15 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
+    <test id="OJT2">
         <title>Period containment of registry entries</title>
+        <description>
+            Tests whether the created and finalized dates of all registry entries in offentligJournal.xml
+            are within the archival period specified in arkivuttrekk.xml, and whether the same registry entries
+            (same systemIDs) can be found in arkivstruktur.xml.
+        </description>
         <group>offentligjournal</group>
         <queries>
             <info>
@@ -2421,10 +2591,18 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
-    <rule>
-        <title>Number of changes in endringslogg</title>
+    <!--
+    ============================================================================================================
+    ENDRINGSLOGG
+    ============================================================================================================
+    -->
+    <!-- Checks -->
+
+    <check id="ELC1">
+        <title>Change log entries</title>
+        <description>Provides information about the number of change log entries in endringslogg.xml.</description>
         <group>endringslogg</group>
         <queries>
             <info>
@@ -2434,10 +2612,16 @@
                 ]]>
             </info>
         </queries>
-    </rule>
+    </check>
 
-    <rule>
-        <title>Check the references in endringslogg</title>
+    <!-- Tests -->
+
+    <test id="ELT1">
+        <title>Change log references</title>
+        <description>
+            Tests whether all objects referenced in the change log can be found
+            by their systemID in arkivstruktur.xml.
+        </description>
         <group>endringslogg</group>
         <queries>
             <info>
@@ -2526,6 +2710,6 @@
                 ]]>
             </warnings>
         </queries>
-    </rule>
+    </test>
 
 </validation>

--- a/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xsd
+++ b/noark-extraction-validator/src/main/resources/noark53/noark53-validation.xsd
@@ -1,46 +1,81 @@
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+		   xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-  <xs:element name="validation" type="validation"/>
+	<xs:element name="validation" type="validation"/>
 
-  <xs:complexType name="validation">
-    <xs:sequence>
-      <xs:element name="target" type="xs:string" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="rule" type="rule" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
-  </xs:complexType>
+	<xs:complexType name="validation">
+		<xs:sequence>
+			<xs:element name="target" type="xs:string"/>
+			<xs:sequence minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="check" type="check" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="test" type="test" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
 
-  <xs:complexType name="rule">
-    <xs:sequence>
-      <xs:element name="title" type="title" minOccurs="1" maxOccurs="1" />
-      <xs:element name="group" type="group" minOccurs="1" maxOccurs="1" />
-      <xs:element name="queries" type="queries" minOccurs="1" maxOccurs="1" />
-    </xs:sequence>
-  </xs:complexType>
+	<xs:complexType name="rule">
+		<xs:sequence>
+			<xs:element name="title" type="title"/>
+			<xs:element name="description" type="xs:string"/>
+			<xs:element name="group" type="group"/>
+		</xs:sequence>
+		<xs:attribute name="id" use="required"/>
+	</xs:complexType>
 
-  <xs:complexType name="queries">
-    <xs:sequence>
-      <xs:element name="info" type="xs:string" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="warnings" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="errors" type="xs:string" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
-  </xs:complexType>
+	<xs:complexType name="check">
+		<xs:complexContent>
+			<xs:extension base="rule">
+				<xs:sequence>
+					<xs:element name="queries" type="informationQueries"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 
-  <xs:simpleType name="group">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="arkivstruktur"/>
-      <xs:enumeration value="loependejournal"/>
-      <xs:enumeration value="offentligjournal"/>
-      <xs:enumeration value="arkivuttrekk"/>
-      <xs:enumeration value="endringslogg"/>
-      <xs:enumeration value="common"/>
-    </xs:restriction>
-  </xs:simpleType>
+	<xs:complexType name="test">
+		<xs:complexContent>
+			<xs:extension base="rule">
+				<xs:sequence>
+					<xs:element name="queries" type="validationQueries"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 
-  <xs:simpleType name="title">
-    <xs:restriction base="xs:string">
-      <xs:minLength value="3" />
-      <xs:maxLength value="50" />
-    </xs:restriction>
-  </xs:simpleType>
+	<xs:complexType name="informationQueries">
+		<xs:sequence>
+			<xs:element name="info" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="validationQueries">
+		<xs:complexContent>
+			<xs:extension base="informationQueries">
+				<xs:sequence minOccurs="1">
+					<xs:element name="warnings" type="xs:string" minOccurs="0" maxOccurs="1"/>
+					<xs:element name="errors" type="xs:string" minOccurs="0" maxOccurs="1"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:simpleType name="group">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="arkivstruktur"/>
+			<xs:enumeration value="loependejournal"/>
+			<xs:enumeration value="offentligjournal"/>
+			<xs:enumeration value="arkivuttrekk"/>
+			<xs:enumeration value="endringslogg"/>
+			<xs:enumeration value="package"/>
+			<xs:enumeration value="exceptions"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="title">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="3"/>
+			<xs:maxLength value="50"/>
+		</xs:restriction>
+	</xs:simpleType>
 
 </xs:schema>

--- a/noark-extraction-validator/src/main/resources/reporting/xml-report.xsd
+++ b/noark-extraction-validator/src/main/resources/reporting/xml-report.xsd
@@ -18,7 +18,7 @@
         <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="parameter" type="dm:parameter"/>
         </xs:choice>
-        <xs:attribute name="Version" type="xs:string" use="required"/>
+        <xs:attribute name="version" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="parameter">
@@ -61,6 +61,7 @@
         </xs:choice>
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="description" type="xs:string" use="required"/>
         <xs:attribute name="info" type="xs:integer" use="required"/>
         <xs:attribute name="warn" type="xs:integer" use="required"/>
         <xs:attribute name="error" type="xs:integer" use="required"/>


### PR DESCRIPTION
Enhanced validation rules:
* Separated validation rules to checks and tests
    * Checks can produce only information
    * Tests can also produce warnings and errors
* Added hard-coded test IDs
* Added descriptions to all validation tests and checks
* Reordered all validation rules so that checks appear before tests
    in all reports
* Added/updated relevant classes to enable JAXB marshalling of the
    noark53-validation.xml file

Minor refactoring in ValidationCollector:
* Extracted ValidationCollector inner classes
* ValidationStatusCode --> ValidationStatus
* ValidationResult now expects group names instead of ValidationGroups
    since ValidationGroups were not a part of the ValidationCollector
    contract

Updated XMLReport and ExcelReport to accommodate the changes introduced
in the validation framework