### PR TITLE
Support for custom validation schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ You can request a report to be generated in multiple formats:
 ```
 java -jar noark-extraction-validator-0.2.0.jar noark53 -extraction /path/to/uttrekk/directory -output-dir /path/to/report/output/directory -output-type excel_xls -output-type xml
 ```
+You can specify custom Noark schemas to be used in the validation process (in addition to the Noark ones and the extraction package ones). In such cases the reports would also include information about the compliance of the extraction package to these schemas:
+```
+java -jar noark-extraction-validator-0.2.0.jar noark53 -extraction /path/to/uttrekk/directory -custom-schema-location /path/to/custom/schemas/directory
+```
+The specified `-custom-schema-location` directory may contain any custom Noark 5 schemas and a UTF-8-encoded description.txt file. The contents of this file will be copied to the Execution Information sections of the generated reports for completeness.
+
+
 You can also change the persistence settings:
 ```
 java -jar noark-extraction-validator-0.2.0.jar noark53 -extraction /path/to/uttrekk/directory -output-dir /path/to/report/output/directory -db-name myDBName -storage hsqldb_server -server-location http://my.hsqldb.server.com

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
@@ -20,7 +20,9 @@ package com.documaster.validator.config.commands;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -70,7 +72,10 @@ public abstract class Command<T extends InternalProperties> {
 			parameters.add(new ParameterInfo(param));
 		}
 
-		return new ExecutionInfo(parameters);
+		ExecutionInfo executionInfo = new ExecutionInfo(parameters);
+		executionInfo.addGeneralInfo("command", getName());
+
+		return executionInfo;
 	}
 
 	/**
@@ -83,36 +88,63 @@ public abstract class Command<T extends InternalProperties> {
 	 */
 	public abstract T getProperties() throws Exception;
 
+	/**
+	 * Provides execution information.
+	 */
 	public static class ExecutionInfo {
 
-		List<ParameterInfo> parameterInfo;
+		private List<ParameterInfo> parameterInfo = new LinkedList<>();
+
+		private Map<String, Object> generalInfo = new HashMap<>();
+
+		private Map<String, String> commandInfo = new HashMap<>();
 
 		ExecutionInfo(List<ParameterInfo> parameterInfo) {
 
-			this.parameterInfo = parameterInfo;
+			this.parameterInfo.addAll(parameterInfo);
 		}
 
 		/**
-		 * Retrieves information about the parameters used in this execution.
+		 * Returns an unmodifiable list containing the parameters of this execution.
 		 */
 		public List<ParameterInfo> getParameterInfo() {
 
-			return parameterInfo;
+			return Collections.unmodifiableList(parameterInfo);
 		}
 
 		/**
-		 * Retrieves general (usually static) information about this execution, such as:
+		 * Retrieves an unmodifiable map of general (usually static) information about this execution, such as:
 		 * <ul>
 		 * <li>Build version</li>
+		 * <li>Time of execution</li>
 		 * </ul>
 		 */
 		public Map<String, Object> getGeneralInfo() {
 
-			Map<String, Object> generalInfo = new HashMap<>();
 			generalInfo.put("version", getClass().getPackage().getImplementationVersion());
+			generalInfo.put("generated", new Date());
 
 			return Collections.unmodifiableMap(generalInfo);
 		}
+
+		public void addGeneralInfo(String name, String value) {
+
+			generalInfo.put(name, value);
+		}
+
+		/**
+		 * Retrieves an unmodifiable map of {@link Command}-specific execution information.
+		 */
+		public Map<String, String> getCommandInfo() {
+
+			return Collections.unmodifiableMap(commandInfo);
+		}
+
+		public void addCommandInfo(String title, String value) {
+
+			commandInfo.put(title, value);
+		}
+
 	}
 
 	/**

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/exceptions/aggregation/ExceptionAggregator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/exceptions/aggregation/ExceptionAggregator.java
@@ -1,0 +1,13 @@
+package com.documaster.validator.exceptions.aggregation;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ExceptionAggregator<T extends Exception> {
+
+	/**
+	 * Aggregates the specified {@link List} of {@link T} exceptions by their message property and returns a {@link Map}
+	 * holding the aggregated exception messages as keys and the number of their occurrences.
+	 */
+	Map<String, Long> aggregate(List<T> exceptions);
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/exceptions/aggregation/SAXParseExceptionAggregator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/exceptions/aggregation/SAXParseExceptionAggregator.java
@@ -1,0 +1,105 @@
+package com.documaster.validator.exceptions.aggregation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.xml.sax.SAXParseException;
+
+public class SAXParseExceptionAggregator<T extends SAXParseException> implements ExceptionAggregator<T> {
+
+	/**
+	 * Non-greedy regex matching the first occurrence of any value in single quotes.
+	 */
+	private final static String VALUE_MATCHING_REGEX = "'.*?'";
+	private static final String DEFAULT_REPLACE_STRING = "X";
+
+	private String replaceString = DEFAULT_REPLACE_STRING;
+
+	/**
+	 * Get the current {@code replaceString}.
+	 */
+	public String getReplaceString() {
+
+		return replaceString;
+	}
+
+	/**
+	 * Change the default {@code replaceString} ({@link SAXParseExceptionAggregator#DEFAULT_REPLACE_STRING}).
+	 */
+	public void setReplaceString(String replaceString) {
+
+		this.replaceString = replaceString;
+	}
+
+	/**
+	 * Aggregates the {@link SAXParseException}s based on their {@link SAXParseException#getMessage()} values and
+	 * returns the number of occurrences of each.
+	 * <p/>
+	 * Note that some parts of the aggregated exception messages may be modified when added to the result set
+	 * in order to ensure true aggregation. Such <i>parts</i> may include any non-deterministic information
+	 * provided by the {@link SAXParseException}s.
+	 * <p/>
+	 * For example, the following exception messages:
+	 * <pre>
+	 * cvc-datatype-valid.1.2.1: '2017-01-01' is not a valid value for 'dateTime'
+	 * cvc-datatype-valid.1.2.1: '2017-01-02' is not a valid value for 'dateTime'
+	 * cvc-datatype-valid.1.2.1: '2017-01-03' is not a valid value for 'dateTime'
+	 * </pre>
+	 * will have their <i>arbitrary values</i> ('2017-01-0[1,2,3]') replaced by the {@code replaceString}.
+	 * As a result, the three exception messages will be grouped together to produce the following output
+	 * (assuming that the {@code replaceString} is <b>X</b>):
+	 * <pre>
+	 * {cvc-datatype-valid.1.2.1: X is not a valid value for 'dateTime': 3}
+	 * </pre>
+	 * The logic in this method relies on the fact that the Xerces XML parser is used. The list of exception message
+	 * definitions can be found in {@code org.apache.xerces.impl.msg.XMLSchemaMessages}.
+	 *
+	 * @param exceptions
+	 * 		A {@link List} of {@link SAXParseException}s to aggregate
+	 * @return A {@link Map} whose keys are the (modified) exception messages and whose values are the number of times
+	 * they occur
+	 */
+	@Override
+	public Map<String, Long> aggregate(List<T> exceptions) {
+
+		return exceptions.stream()
+				.map(ex -> {
+					String msg = ex.getMessage();
+					switch (msg.substring(0, msg.indexOf(":"))) {
+						case "cvc-attribute.3":
+						case "cvc-attribute.4":
+						case "cvc-complex-type.3.1":
+						case "cvc-complex-type.3.2.2":
+						case "cvc-datatype-valid.1.2.1":
+						case "cvc-datatype-valid.1.2.2":
+						case "cvc-datatype-valid.1.2.3":
+						case "cvc-elt.4.1":
+						case "cvc-elt.4.2":
+						case "cvc-elt.4.3":
+						case "cvc-elt.5.1.1":
+						case "cvc-elt.5.2.2.2.1":
+						case "cvc-elt.5.2.2.2.2":
+						case "cvc-enumeration-valid":
+						case "cvc-maxExclusive-valid":
+						case "cvc-maxInclusive-valid":
+						case "cvc-minExclusive-valid":
+						case "cvc-minInclusive-valid":
+						case "cvc-pattern-valid":
+						case "cvc-type.3.1.3":
+							return msg.replaceFirst(VALUE_MATCHING_REGEX, replaceString);
+						case "cvc-fractionDigits-valid":
+						case "cvc-length-valid":
+						case "cvc-maxLength-valid":
+						case "cvc-minLength-valid":
+						case "cvc-totalDigits-valid":
+							return msg.replaceFirst(VALUE_MATCHING_REGEX, replaceString)
+									.replaceFirst(VALUE_MATCHING_REGEX, replaceString);
+						default:
+							// Keep all other messages the way they are
+							return msg;
+					}
+				})
+				.collect(Collectors.groupingBy(m -> m, Collectors.counting()));
+	}
+}

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
@@ -125,21 +125,45 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 		ExcelUtils.createCell("Required", 3, styles.get(StyleName.RESULT_HEADER_ROW), parametersHeaderRow);
 
 		// Parameters
-		for (Command.ParameterInfo parameter : getConfig().getExecutionInfo().getParameterInfo()) {
-			if (parameter.isDefault()) {
+		for (Command.ParameterInfo parameterInfo : getConfig().getExecutionInfo().getParameterInfo()) {
+			if (parameterInfo.isDefault()) {
 				// Skip default parameters
 				continue;
 			}
 			Row row = ExcelUtils.createRow(executionInfoSheet);
-			ExcelUtils.createCell(parameter.getName(), 0, row);
-			ExcelUtils.createCell(parameter.getSpecifiedValue(), 1, row);
-			ExcelUtils
-					.createCell(!StringUtils.isBlank(parameter.getDescription()) ? parameter.getDescription() : "-", 2,
-							row);
-			ExcelUtils.createCell(parameter.isRequired(), 3, row);
+			ExcelUtils.createCell(parameterInfo.getName(), 0, row);
+			ExcelUtils.createCell(parameterInfo.getSpecifiedValue(), 1, row);
+			ExcelUtils.createCell(
+					!StringUtils.isBlank(parameterInfo.getDescription()) ? parameterInfo.getDescription() : "-",
+					2,
+					row);
+			ExcelUtils.createCell(parameterInfo.isRequired(), 3, row);
 		}
 
-		ExcelUtils.autoSizeColumns(executionInfoSheet, 0, 4, 50);
+		// Command-specific information
+		if (!getConfig().getExecutionInfo().getCommandInfo().isEmpty()) {
+			getConfig().getExecutionInfo().getCommandInfo().entrySet().forEach(e -> {
+				// Empty row
+				ExcelUtils.createRow(executionInfoSheet);
+
+				// Header
+				ExcelUtils.createCell(e.getKey(), 0, styles.get(StyleName.GROUP),
+						ExcelUtils.createRow(25, executionInfoSheet));
+
+				// Value
+				Row valueRow = ExcelUtils.createRow(executionInfoSheet);
+
+				// Automatically determine the height for the row (works in MS Excel, but no in LibreOffice)
+				CellStyle style = ExcelUtils.createDefaultCellStyle(workbook);
+				style.setFont(ExcelUtils.createDefaultFont(workbook, (short) 10, false));
+				style.setWrapText(true);
+
+				ExcelUtils.createCell(e.getValue(), 0, style, valueRow);
+			});
+
+		}
+
+		ExcelUtils.autoSizeColumns(executionInfoSheet, 0, 4, 50 * 256);
 	}
 
 	/**

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
@@ -25,6 +25,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import com.documaster.validator.config.commands.Command;
 import com.documaster.validator.config.delegates.ConfigurableReporting;
@@ -100,7 +101,7 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 		placeTotalsInSummaryTable();
 
-		ExcelUtils.autoSizeColumns(summary, 0, 4);
+		ExcelUtils.autoSizeColumns(summary, 0, 5);
 		summary.setColumnWidth(0, 256);
 
 		ExcelUtils.freezePanes(summary, summaryTableRowIndex + 1, 0);
@@ -162,11 +163,9 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 		// Place group-by-group summary table headers
 		Row summaryHeaderRow = ExcelUtils.createRow(25, summarySheet);
-		ExcelUtils.createCell("", 0, styles.get(StyleName.GROUP), summaryHeaderRow);
-		ExcelUtils.createCell("Group name", 1, styles.get(StyleName.GROUP), summaryHeaderRow);
-		ExcelUtils.createCell("Information", 2, styles.get(StyleName.GROUP), summaryHeaderRow);
-		ExcelUtils.createCell("Warnings", 3, styles.get(StyleName.GROUP), summaryHeaderRow);
-		ExcelUtils.createCell("Errors", 4, styles.get(StyleName.GROUP), summaryHeaderRow);
+		String[] headers = new String[] { "", "Group name", "Summary", "Information", "Warnings", "Errors" };
+		IntStream.range(0, headers.length)
+				.forEach(ix -> ExcelUtils.createCell(headers[ix], ix, styles.get(StyleName.GROUP), summaryHeaderRow));
 
 		summaryTableRowIndex = summarySheet.getLastRowNum() + 1;
 
@@ -192,19 +191,24 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 				groupTitle, 1, styles.get(StyleName.RESULT_TITLE), summary.getRow(summaryTableRowIndex),
 				groupTitleCell);
 
+		// Summary count column
+		ExcelUtils.createCell(
+				Integer.toString(ValidationCollector.get().getSummaryCountIn(groupTitle)), 2,
+				summary.getRow(summaryTableRowIndex));
+
 		// Information count column
 		ExcelUtils.createCell(
-				Integer.toString(ValidationCollector.get().getInformationCountIn(groupTitle)), 2,
+				Integer.toString(ValidationCollector.get().getInformationCountIn(groupTitle)), 3,
 				summary.getRow(summaryTableRowIndex));
 
 		// Warning count column
 		ExcelUtils.createCell(
-				Integer.toString(ValidationCollector.get().getWarningCountIn(groupTitle)), 3,
+				Integer.toString(ValidationCollector.get().getWarningCountIn(groupTitle)), 4,
 				summary.getRow(summaryTableRowIndex));
 
 		// Error count column
 		ExcelUtils.createCell(
-				Integer.toString(ValidationCollector.get().getErrorCountIn(groupTitle)), 4,
+				Integer.toString(ValidationCollector.get().getErrorCountIn(groupTitle)), 5,
 				summary.getRow(summaryTableRowIndex));
 
 		summaryTableRowIndex++;
@@ -218,19 +222,24 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 		// Title column
 		ExcelUtils.createCell("Total", 1, styles.get(StyleName.RESULT_TITLE), summary.getRow(summaryTableRowIndex));
 
+		// Summary count column
+		ExcelUtils.createCell(
+				Integer.toString(ValidationCollector.get().getTotalSummaryCount()), 2,
+				summary.getRow(summaryTableRowIndex));
+
 		// Information count column
 		ExcelUtils.createCell(
-				Integer.toString(ValidationCollector.get().getTotalInformationCount()), 2,
+				Integer.toString(ValidationCollector.get().getTotalInformationCount()), 3,
 				summary.getRow(summaryTableRowIndex));
 
 		// Warning count column
 		ExcelUtils.createCell(
-				Integer.toString(ValidationCollector.get().getTotalWarningCount()), 3,
+				Integer.toString(ValidationCollector.get().getTotalWarningCount()), 4,
 				summary.getRow(summaryTableRowIndex));
 
 		// Error count column
 		ExcelUtils.createCell(
-				Integer.toString(ValidationCollector.get().getTotalErrorCount()), 4,
+				Integer.toString(ValidationCollector.get().getTotalErrorCount()), 5,
 				summary.getRow(summaryTableRowIndex));
 
 		summaryTableRowIndex++;
@@ -240,11 +249,9 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 		Row groupRow = ExcelUtils.createRow(25, summary);
 
-		ExcelUtils.createCell("", 0, styles.get(StyleName.GROUP), groupRow);
-		Cell groupTitleCell = ExcelUtils.createCell(groupTitle, 1, styles.get(StyleName.GROUP), groupRow);
-		ExcelUtils.createCell("", 2, styles.get(StyleName.GROUP), groupRow);
-		ExcelUtils.createCell("", 3, styles.get(StyleName.GROUP), groupRow);
-		ExcelUtils.createCell("", 4, styles.get(StyleName.GROUP), groupRow);
+		// Create group header and place the group title in the second cell
+		IntStream.range(0, 6).forEach(
+				i -> ExcelUtils.createCell(i == 1 ? groupTitle : "", i, styles.get(StyleName.GROUP), groupRow));
 
 		for (ValidationResult result : groupResults) {
 
@@ -261,31 +268,37 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 			ExcelUtils.addHyperLink(titleCell, cells.get("firstRow"));
 
+			// Summary entries count
+			Cell summaryCell = ExcelUtils.createCell(
+					MessageFormat.format("Summary ({0})", result.getSummary().size()), 2,
+					styles.get(StyleName.LINK), resultRow);
+			ExcelUtils.addHyperLink(summaryCell, cells.get("summary"));
+
 			// Information entries count
 			Cell informationCell = ExcelUtils.createCell(
-					MessageFormat.format("Information ({0})", result.getInformation().size()), 2,
+					MessageFormat.format("Information ({0})", result.getInformation().size()), 3,
 					styles.get(StyleName.LINK), resultRow);
 			ExcelUtils.addHyperLink(informationCell, cells.get("information"));
 
 			// Warning entries count
 			Cell warningCell = ExcelUtils.createCell(
-					MessageFormat.format("Warnings ({0})", result.getWarnings().size()), 3, styles.get(StyleName.LINK),
+					MessageFormat.format("Warnings ({0})", result.getWarnings().size()), 4, styles.get(StyleName.LINK),
 					resultRow);
 			ExcelUtils.addHyperLink(warningCell, cells.get("warning"));
 
 			// Error entries count
 			Cell errorCell = ExcelUtils.createCell(
-					MessageFormat.format("Errors ({0})", result.getErrors().size()), 4, styles.get(StyleName.LINK),
+					MessageFormat.format("Errors ({0})", result.getErrors().size()), 5, styles.get(StyleName.LINK),
 					resultRow);
 			ExcelUtils.addHyperLink(errorCell, cells.get("error"));
 		}
 
-		return groupTitleCell;
+		return groupRow.getCell(1); // Title cell
 	}
 
 	/**
 	 * Creates a new sheet from the specified {@link ValidationResult} and returns the row indices
-	 * of the "Information", "Warning", and "Error" entries.
+	 * of the "Summary", "Information", "Warning", and "Error" entries.
 	 */
 	private Map<String, Cell> createDetailsSheet(ValidationResult result, Cell referenceCell) {
 
@@ -306,6 +319,11 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 		ExcelUtils.createCell("Title: " + result.getTitle(), 0, resultStyle, titleRow);
 
 		// Index cells
+		int summaryEntries = result.getSummary() == null ? 0 : result.getSummary().size();
+		String indexSummaryTitle = MessageFormat.format("Summary ({0})", summaryEntries);
+		Cell indexSummaryCell = ExcelUtils.createCell(
+				indexSummaryTitle, 0, styles.get(StyleName.LINK), ExcelUtils.createRow(resultSheet));
+
 		int informationEntries = result.getInformation() == null ? 0 : result.getInformation().size();
 		String indexInformationTitle = MessageFormat.format("Information ({0})", informationEntries);
 		Cell indexInformationCell = ExcelUtils.createCell(
@@ -327,6 +345,11 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 		ExcelUtils.createCell(result.getDescription(), 0, styles.get(StyleName.RESULT_DESCRIPTION), descriptionRow);
 
 		// Entries
+		Cell summaryTitleCell = writeDetailEntries(resultSheet, result.getSummary(), "Summary");
+		headerCells.put("summary", summaryTitleCell);
+		ExcelUtils.addHyperLink(indexSummaryCell, summaryTitleCell);
+		ExcelUtils.createRow(resultSheet); // empty row
+
 		Cell informationTitleCell = writeDetailEntries(resultSheet, result.getInformation(), "Information");
 		headerCells.put("information", informationTitleCell);
 		ExcelUtils.addHyperLink(indexInformationCell, informationTitleCell);

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
@@ -153,7 +153,7 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 				// Value
 				Row valueRow = ExcelUtils.createRow(executionInfoSheet);
 
-				// Automatically determine the height for the row (works in MS Excel, but no in LibreOffice)
+				// Automatically determine the height of the row (works in MS Excel, but no in LibreOffice)
 				CellStyle style = ExcelUtils.createDefaultCellStyle(workbook);
 				style.setFont(ExcelUtils.createDefaultFont(workbook, (short) 10, false));
 				style.setWrapText(true);

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
@@ -116,6 +116,15 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 			// End parameter
 			end();
 		}
+
+		// Command-specific (other) information
+		for (Map.Entry<String, String> commandInfo : getConfig().getExecutionInfo().getCommandInfo().entrySet()) {
+			start("other");
+			attr("name", commandInfo.getKey());
+			cdataContent(commandInfo.getValue());
+			end();
+		}
+
 		// End section
 		end();
 	}
@@ -255,6 +264,11 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 	private void content(Object data) throws XMLStreamException {
 
 		writer.writeCharacters(data != null ? data.toString() : "-");
+	}
+
+	private void cdataContent(Object data) throws XMLStreamException {
+
+		writer.writeCData(data != null ? data.toString() : "-");
 	}
 
 	private void end() throws XMLStreamException {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
@@ -123,6 +123,7 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 	private void writeValidationSummary() throws XMLStreamException {
 
 		start("summary");
+		attr("summary", ValidationCollector.get().getTotalSummaryCount());
 		attr("info", ValidationCollector.get().getTotalInformationCount());
 		attr("warn", ValidationCollector.get().getTotalWarningCount());
 		attr("error", ValidationCollector.get().getTotalErrorCount());
@@ -155,6 +156,7 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 
 				startTest(test);
 
+				testDetails("summary", test.getSummary());
 				testDetails("info", test.getInformation());
 				testDetails("warn", test.getWarnings());
 				testDetails("error", test.getErrors());
@@ -199,6 +201,7 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 		start("group");
 
 		attr("name", groupName);
+		attr("summary", ValidationCollector.get().getSummaryCountIn(groupName));
 		attr("info", ValidationCollector.get().getInformationCountIn(groupName));
 		attr("warn", ValidationCollector.get().getWarningCountIn(groupName));
 		attr("error", ValidationCollector.get().getErrorCountIn(groupName));
@@ -211,6 +214,7 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 		attr("id", test.getId());
 		attr("name", test.getTitle());
 		attr("description", test.getDescription());
+		attr("summary", test.getSummary().size());
 		attr("info", test.getInformation().size());
 		attr("warn", test.getWarnings().size());
 		attr("error", test.getErrors().size());

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
@@ -165,8 +165,16 @@ public class ExcelUtils {
 
 	public static void autoSizeColumns(Sheet sheet, int startCol, int endCol) {
 
+		autoSizeColumns(sheet, startCol, endCol, null);
+	}
+
+	public static void autoSizeColumns(Sheet sheet, int startCol, int endCol, Integer maxWidth) {
+
 		for (int i = startCol; i <= endCol; i++) {
 			sheet.autoSizeColumn(i);
+			if (maxWidth != null && maxWidth > 0 && sheet.getColumnWidth(i) > maxWidth) {
+				sheet.setColumnWidth(i, maxWidth);
+			}
 		}
 	}
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationCollector.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationCollector.java
@@ -28,10 +28,12 @@ public class ValidationCollector {
 
 	private Map<String, List<ValidationResult>> results;
 
+	private int totalSummaryCount = 0;
 	private int totalInformationCount = 0;
 	private int totalWarningCount = 0;
 	private int totalErrorCount = 0;
 
+	private Map<String, Integer> summaryCount;
 	private Map<String, Integer> informationCount;
 	private Map<String, Integer> warningCount;
 	private Map<String, Integer> errorCount;
@@ -42,6 +44,7 @@ public class ValidationCollector {
 
 		results = new LinkedHashMap<>();
 
+		summaryCount = new HashMap<>();
 		informationCount = new HashMap<>();
 		warningCount = new HashMap<>();
 		errorCount = new HashMap<>();
@@ -62,6 +65,11 @@ public class ValidationCollector {
 		return results;
 	}
 
+	public int getTotalSummaryCount() {
+
+		return totalSummaryCount;
+	}
+
 	public int getTotalInformationCount() {
 
 		return totalInformationCount;
@@ -75,6 +83,11 @@ public class ValidationCollector {
 	public int getTotalErrorCount() {
 
 		return totalErrorCount;
+	}
+
+	public int getSummaryCountIn(String groupName) {
+
+		return summaryCount.containsKey(groupName) ? summaryCount.get(groupName) : 0;
 	}
 
 	public int getInformationCountIn(String groupName) {
@@ -115,10 +128,12 @@ public class ValidationCollector {
 			results.put(groupName, new ArrayList<>(Collections.singletonList(result)));
 		}
 
+		putOrIncrementMapCounter(summaryCount, groupName, result.getSummary().size());
 		putOrIncrementMapCounter(informationCount, groupName, result.getInformation().size());
 		putOrIncrementMapCounter(warningCount, groupName, result.getWarnings().size());
 		putOrIncrementMapCounter(errorCount, groupName, result.getErrors().size());
 
+		totalSummaryCount += result.getSummary().size();
 		totalInformationCount += result.getInformation().size();
 		totalWarningCount += result.getWarnings().size();
 		totalErrorCount += result.getErrors().size();

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationResult.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationResult.java
@@ -29,6 +29,7 @@ public class ValidationResult {
 	private String description;
 	private String groupName;
 
+	private List<BaseItem> summary = new ArrayList<>();
 	private List<BaseItem> information = new ArrayList<>();
 	private List<BaseItem> warnings = new ArrayList<>();
 	private List<BaseItem> errors = new ArrayList<>();
@@ -61,6 +62,21 @@ public class ValidationResult {
 	public String getGroupName() {
 
 		return groupName;
+	}
+
+	public List<BaseItem> getSummary() {
+
+		return summary;
+	}
+
+	public void addSummary(BaseItem summaryEntry) {
+
+		getSummary().add(summaryEntry);
+	}
+
+	public void addSummaries(List<BaseItem> summaryEntries) {
+
+		getSummary().addAll(summaryEntries);
 	}
 
 	public List<BaseItem> getInformation() {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/Noark53Validator.java
@@ -142,7 +142,9 @@ public class Noark53Validator extends Validator<Noark53Command> {
 		File tempNoarkSchemasDirectory = Files.createTempDirectory("noark-extraction-validator-").toFile();
 
 		// Initialize the package structure
-		structure = new Noark53PackageStructure(getCommand().getExtractionDirectory(), tempNoarkSchemasDirectory);
+		structure = new Noark53PackageStructure(
+				getCommand().getExtractionDirectory(), tempNoarkSchemasDirectory,
+				getCommand().getCustomSchemaLocation());
 
 		// Create temporary files containing the original Noark 5.3 schemas
 		for (Noark53PackageEntity entity : structure.values()) {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageEntity.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageEntity.java
@@ -97,4 +97,34 @@ public class Noark53PackageEntity {
 
 		return Collections.unmodifiableList(noarkSchemas);
 	}
+
+	/**
+	 * Retrieves the custom schema files.
+	 * <br/>
+	 * The corresponding Noark 5.3 XSD schema is returned for each schema not found in custom schemas.
+	 */
+	public List<File> getCustomSchemas() {
+
+		List<File> customSchemas = new ArrayList<>();
+
+		for (String xsdSchemaName : xsdSchemasNames) {
+
+			// Custom schema
+			File schema = new File(structure.getCustomSchemasDirectory(), xsdSchemaName);
+
+			if (!schema.isFile()) {
+				// Fallback to Noark schema
+				schema = new File(structure.getNoarkSchemasDirectory(), xsdSchemaName);
+			}
+
+			customSchemas.add(schema);
+		}
+
+		return Collections.unmodifiableList(customSchemas);
+	}
+
+	public boolean hasCustomSchemas() {
+
+		return structure.getCustomSchemasDirectory() != null;
+	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageStructure.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/model/Noark53PackageStructure.java
@@ -18,20 +18,18 @@
 package com.documaster.validator.validation.noark53.model;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.commons.lang.Validate;
 
 /**
  * The Noark 5.3 extraction package structure represented as a {@link HashMap} implementation.
+ * <p/>
+ * {@link Noark53PackageStructure} provides support for optional external schemas apart from the Noark ones and the ones
+ * included in the package.
  * <p/>
  * <b>keys: </b> XML file names<br/>
  * <b>values: </b> {@link Noark53PackageEntity}
@@ -40,14 +38,21 @@ public class Noark53PackageStructure extends HashMap<String, Noark53PackageEntit
 
 	private File extractionDirectory;
 	private File noarkSchemasDirectory;
+	private File customSchemasDirectory;
 
 	public Noark53PackageStructure(File extractionDirectory, File noarkSchemasDirectory) {
+
+		this(extractionDirectory, noarkSchemasDirectory, null);
+	}
+
+	public Noark53PackageStructure(File extractionDirectory, File noarkSchemasDirectory, File customSchemasDirectory) {
 
 		Validate.isTrue(extractionDirectory.isDirectory());
 		Validate.isTrue(noarkSchemasDirectory.isDirectory());
 
 		this.extractionDirectory = extractionDirectory;
 		this.noarkSchemasDirectory = noarkSchemasDirectory;
+		this.customSchemasDirectory = customSchemasDirectory;
 
 		put(
 				"arkivstruktur.xml",
@@ -68,6 +73,11 @@ public class Noark53PackageStructure extends HashMap<String, Noark53PackageEntit
 	public File getNoarkSchemasDirectory() {
 
 		return noarkSchemasDirectory;
+	}
+
+	public File getCustomSchemasDirectory() {
+
+		return customSchemasDirectory;
 	}
 
 	public List<File> getAllNoarkSchemaFiles() {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/utils/AbstractReusableXMLHandler.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/utils/AbstractReusableXMLHandler.java
@@ -36,6 +36,11 @@ public abstract class AbstractReusableXMLHandler extends DefaultHandler {
 	public abstract boolean hasExceptions();
 
 	/**
+	 * Returns a summary of the encountered exceptions as {@link BaseItem}s.
+	 */
+	public abstract List<BaseItem> getSummaryOfExceptionsAsItems();
+
+	/**
 	 * Sorts the encountered exceptions and returns an ordered list of {@link BaseItem}s created from the sorted list of
 	 * exceptions.
 	 * <br/>

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/utils/DefaultXMLHandler.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/utils/DefaultXMLHandler.java
@@ -17,13 +17,14 @@
  */
 package com.documaster.validator.validation.utils;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
+import com.documaster.validator.exceptions.aggregation.SAXParseExceptionAggregator;
 import com.documaster.validator.storage.model.BaseItem;
 import org.xml.sax.SAXParseException;
 
@@ -33,11 +34,24 @@ import org.xml.sax.SAXParseException;
  */
 public class DefaultXMLHandler extends AbstractReusableXMLHandler {
 
-	private List<SAXParseException> exceptions = new ArrayList<>();
+	private List<SAXParseException> exceptions = new LinkedList<>();
 
 	public boolean hasExceptions() {
 
 		return !exceptions.isEmpty();
+	}
+
+	@Override
+	public List<BaseItem> getSummaryOfExceptionsAsItems() {
+
+		return new SAXParseExceptionAggregator<>()
+				.aggregate(exceptions)
+				.entrySet()
+				.stream()
+				.map(k -> new BaseItem()
+						.add("Message", k.getKey())
+						.add("Count", k.getValue()))
+				.collect(collectingAndThen(toList(), Collections::unmodifiableList));
 	}
 
 	public List<BaseItem> getExceptionsAsItems() {

--- a/noark-extraction-validator/src/main/resources/reporting/xml-report.xsd
+++ b/noark-extraction-validator/src/main/resources/reporting/xml-report.xsd
@@ -17,8 +17,11 @@
     <xs:complexType name="execution">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="parameter" type="dm:parameter"/>
+            <xs:element name="other" type="dm:other"/>
         </xs:choice>
         <xs:attribute name="version" type="xs:string" use="required"/>
+        <xs:attribute name="command" type="xs:string" use="required"/>
+        <xs:attribute name="generated" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="parameter">
@@ -26,6 +29,14 @@
         <xs:attribute name="description" type="xs:string" use="required"/>
         <xs:attribute name="value" type="xs:string" use="required"/>
         <xs:attribute name="required" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="other">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
     </xs:complexType>
 
     <xs:complexType name="summary">

--- a/noark-extraction-validator/src/main/resources/reporting/xml-report.xsd
+++ b/noark-extraction-validator/src/main/resources/reporting/xml-report.xsd
@@ -32,6 +32,7 @@
         <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="group" type="dm:group"/>
         </xs:choice>
+        <xs:attribute name="summary" type="xs:integer" use="required"/>
         <xs:attribute name="info" type="xs:integer" use="required"/>
         <xs:attribute name="warn" type="xs:integer" use="required"/>
         <xs:attribute name="error" type="xs:integer" use="required"/>
@@ -48,6 +49,7 @@
             <xs:element name="test" type="dm:test"/>
         </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="summary" type="xs:integer" use="required"/>
         <xs:attribute name="info" type="xs:integer" use="required"/>
         <xs:attribute name="warn" type="xs:integer" use="required"/>
         <xs:attribute name="error" type="xs:integer" use="required"/>
@@ -55,6 +57,7 @@
 
     <xs:complexType name="test">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="summary" type="dm:table" minOccurs="0" maxOccurs="1"/>
             <xs:element name="info" type="dm:table" minOccurs="0" maxOccurs="1"/>
             <xs:element name="warn" type="dm:table" minOccurs="0" maxOccurs="1"/>
             <xs:element name="error" type="dm:table" minOccurs="0" maxOccurs="1"/>
@@ -62,6 +65,7 @@
         <xs:attribute name="id" type="xs:string" use="required"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="description" type="xs:string" use="required"/>
+        <xs:attribute name="summary" type="xs:integer" use="required"/>
         <xs:attribute name="info" type="xs:integer" use="required"/>
         <xs:attribute name="warn" type="xs:integer" use="required"/>
         <xs:attribute name="error" type="xs:integer" use="required"/>


### PR DESCRIPTION
**Support for summary entries in the ValidationCollector**

Added support for Summary entries in the ValidationCollector. This
means that reports will now include four types of results:
* Summary
* Information
* Warnings
* Errors
The intended purpose of the Summary entries is to aggregate (summarize)

**Refactored the ExcelReport**

The previous implementation of the ExcelReport generation logic was
relatively difficult to follow due to the multiple links between
methods and unclear naming. There is still room for improvement with
the new implemenation, but the ExcelReport generation logic is now much
more easily readable.

Added JavaDoc describing the purpose and target output for each sheet
in the generated report.

**Support for command-specific execution information**

Added support for arbitrary unstrctured data in the reports' execution
information sections. Such data can be provided by the command or left
blank.

**Support for custom validation schemas**

The Noark 5.3 extraction validation can now use externally-provided
Noark schemas during the validation process. Any incompatibilities
of the XML files included with the custom schemas will be reported
as errors with schema type CUSTOM.

The new «-custom-schema-location» command parameter expects a directory
containing zero or more Noark schemas. Users need not specify all
required schemas in that directory, but if they do, they must use the
Noark 5.3 schema names. If a required schema is not found
in the directory, its Noark 5.3 counterpart will be used instead.

Additionally, a user may include a description.txt file in the
aforementioned directory containing a summary of the changes
included in the specified custom schema files. The content of this file
will be included in the Execution Information section of all reports.

Any other files in the specified directory will simply be ignored.

Introduced exception message aggregators. The aggregators can be used
to group messages based on custom logic. The primary purpose of these
aggregators is to summarize the validation warnings and errors when
verifying the compliance of XML files to their corresponding XSD
schemas. The current implementation is strongly dependent on the
exception messages provided by the Xerces parser.