### PR TITLE
Add support for being included as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ Similar to the above but note that Windows uses a different path separator:
 
 Also note that the above command specifies the path to Java explicitly to make sure that we are using a JDK, not a JRE (if one is installed). There are other ways to achieve the same thing.
 
+**Running as a library**
+
+The application can also be run as a library. To do so, you will need to prepare a command, create a validator, and run it:
+```
+# Initialize report configuration
+ReportConfiguration reportConfiguration = new ReportConfiguration();
+reportConfiguration.setOutputDir(new File("/path/to/output/directory/"));
+reportConfiguration.setOutputTypes(Arrays.asList(ReportType.EXCEL_XLSX, ReportType.XML));
+
+# Create a command
+Noark53Command command = new Noark53Command();
+command.setExtractionDirectory(new File("/path/to/extraction"));
+command.setReportConfiguration(reportConfiguration);
+
+# Create a validator
+Validator validator = ValidationFactory.createValidator(ValidatorType.byName(command.getName()), command);
+
+validator.run();
+```
+
 # Samples
 
 The [Noark Extraction Validator Samples repository](https://github.com/documaster/noark-extraction-validator-samples) contains a number of sample extraction packages and their corresponding validation reports produced by this tool. Note that the samples are of varying quality in order to demonstrate the capabilities of the validator.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ OR
 java -jar noark-extraction-validator-0.2.0.jar --help
 ```
 
+**Logging**
+
+If you would like to enable logging in the console or in a specific file, you will need to provide a reference to a log4j2 configuration:
+```
+java -Dlog4j.configurationFile='/path/to/log4j2.xml' -jar noark-extraction-validator-0.2.0.jar noark53 ...
+```
+A default configuration exists in a directory called `config/`.
+
 **Validating a Noark 5.3 extraction package**
 
 The shortest command to validate a package is:

--- a/noark-extraction-validator/config/log4j2.xml
+++ b/noark-extraction-validator/config/log4j2.xml
@@ -2,29 +2,28 @@
 <configuration status="WARN">
 
 	<properties>
-		<property name="filename">ENTER_FILENAME_HERE</property>
+		<property name="filename">noark-extraction-validator.log</property>
 	</properties>
 
 	<appenders>
+
 		<Console name="Console" target="SYSTEM_OUT">
 			<PatternLayout pattern="%d %p %C{1.} [%t] %m%n"/>
 		</Console>
 
-		<!--
-		<RollingFile name="File" fileName="${filename}"
-				filePattern="${filename}.%i.gz">
-			<PatternLayout pattern="%d %p %C{1.} [%t] %m%n" />
-			<SizeBasedTriggeringPolicy size="10 MB" />
-			<DefaultRolloverStrategy max="9" />
+		<RollingFile name="File" fileName="${filename}" filePattern="${filename}.%i.gz">
+			<PatternLayout pattern="%d %p %C{1.} [%t] %m%n"/>
+			<SizeBasedTriggeringPolicy size="10 MB"/>
+			<DefaultRolloverStrategy max="9"/>
 		</RollingFile>
-		-->
 
 	</appenders>
 
 	<loggers>
 
-		<root level="info">
-			<appender-ref ref="Console"/>
+		<root level="debug">
+			<appender-ref ref="Console" level="info"/>
+			<appender-ref ref="File" level="debug"/>
 		</root>
 
 		<!-- Suppress PDFA Validator -->
@@ -32,6 +31,7 @@
 			<appender-ref ref="Console"/>
 		</logger>
 
+		<!-- Suppress PDFBox -->
 		<logger name="org.apache.pdfbox" additivity="false" level="off">
 			<appender-ref ref="Console"/>
 		</logger>

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Command.java
@@ -38,6 +38,10 @@ public abstract class Command<T extends InternalProperties> {
 
 	private JCommander argParser;
 
+	public Command() {
+
+	}
+
 	public Command(JCommander argParser) {
 
 		this.argParser = argParser;
@@ -68,8 +72,10 @@ public abstract class Command<T extends InternalProperties> {
 
 		List<ParameterInfo> parameters = new ArrayList<>();
 
-		for (ParameterDescription param : argParser.getCommands().get(getName()).getParameters()) {
-			parameters.add(new ParameterInfo(param));
+		if (argParser != null) {
+			for (ParameterDescription param : argParser.getCommands().get(getName()).getParameters()) {
+				parameters.add(new ParameterInfo(param));
+			}
 		}
 
 		ExecutionInfo executionInfo = new ExecutionInfo(parameters);

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Noark53Command.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/commands/Noark53Command.java
@@ -73,6 +73,11 @@ public class Noark53Command extends Command<Noark53Properties> implements Config
 
 	private Noark53Properties properties;
 
+	public Noark53Command() {
+
+		super();
+	}
+
 	public Noark53Command(JCommander argParser) {
 
 		super(argParser);
@@ -83,14 +88,29 @@ public class Noark53Command extends Command<Noark53Properties> implements Config
 		return extractionDirectory;
 	}
 
+	public void setExtractionDirectory(File extractionDirectory) {
+
+		this.extractionDirectory = extractionDirectory;
+	}
+
 	public boolean getIgnoreNonCompliantXML() {
 
 		return ignoreNonCompliantXML;
 	}
 
+	public void setIgnoreNonCompliantXML(boolean ignoreNonCompliantXML) {
+
+		this.ignoreNonCompliantXML = ignoreNonCompliantXML;
+	}
+
 	public File getCustomSchemaLocation() {
 
 		return customSchemaLocation;
+	}
+
+	public void setCustomSchemaLocation(File customSchemaLocation) {
+
+		this.customSchemaLocation = customSchemaLocation;
 	}
 
 	@Override
@@ -99,10 +119,20 @@ public class Noark53Command extends Command<Noark53Properties> implements Config
 		return reportConfiguration;
 	}
 
+	public void setReportConfiguration(ReportConfiguration reportConfiguration) {
+
+		this.reportConfiguration = reportConfiguration;
+	}
+
 	@Override
 	public StorageConfiguration getStorageConfiguration() {
 
 		return storageConfiguration;
+	}
+
+	public void setStorageConfiguration(StorageConfiguration storageConfiguration) {
+
+		this.storageConfiguration = storageConfiguration;
 	}
 
 	@Override

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ReportConfiguration.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ReportConfiguration.java
@@ -55,9 +55,19 @@ public class ReportConfiguration implements Delegate {
 		return outputDir;
 	}
 
+	public void setOutputDir(File outputDir) {
+
+		this.outputDir = outputDir;
+	}
+
 	public List<ReportType> getOutputTypes() {
 
 		return outputTypes;
+	}
+
+	public void setOutputTypes(List<ReportType> outputTypes) {
+
+		this.outputTypes = outputTypes;
 	}
 
 	@Override

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/StorageConfiguration.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/StorageConfiguration.java
@@ -41,14 +41,29 @@ public class StorageConfiguration implements Delegate {
 		return storageType;
 	}
 
+	public void setStorageType(Storage.StorageType storageType) {
+
+		this.storageType = storageType;
+	}
+
 	public String getDatabaseName() {
 
 		return databaseName;
 	}
 
+	public void setDatabaseName(String databaseName) {
+
+		this.databaseName = databaseName;
+	}
+
 	public String getServerLocation() {
 
 		return serverLocation;
+	}
+
+	public void setServerLocation(String serverLocation) {
+
+		this.serverLocation = serverLocation;
 	}
 
 	@Override

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ExcelReport.java
@@ -55,9 +55,9 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 	private Map<StyleName, CellStyle> styles;
 
-	ExcelReport(T config, ReportType reportType, String title) {
+	ExcelReport(T config, ReportType reportType, ValidationCollector collector, String title) {
 
-		super(config, title);
+		super(config, collector, title);
 		this.reportType = reportType;
 	}
 
@@ -286,21 +286,21 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 		Map<String, Cell> groupNameCells = new HashMap<>();
 
-		for (String groupTitle : ValidationCollector.get().getAllResults().keySet()) {
+		for (String groupTitle : getCollector().getAllResults().keySet()) {
 
 			Row groupRow = ExcelUtils.createRow(summarySheet);
 
-			ValidationStatus groupStatus = ValidationCollector.get().getGroupStatus(groupTitle);
+			ValidationStatus groupStatus = getCollector().getGroupStatus(groupTitle);
 			CellStyle groupStatusStyle = getResultStatusStyleFromValidationStatus(groupStatus);
 
 			ExcelUtils.createCell("", 0, groupStatusStyle, groupRow); // Status
 			groupNameCells.put(
 					groupTitle,
 					ExcelUtils.createCell(groupTitle, 1, styles.get(StyleName.RESULT_TITLE), groupRow)); // Title
-			ExcelUtils.createCell(ValidationCollector.get().getSummaryCountIn(groupTitle), 2, groupRow); // Summary
-			ExcelUtils.createCell(ValidationCollector.get().getInformationCountIn(groupTitle), 3, groupRow); // Info
-			ExcelUtils.createCell(ValidationCollector.get().getWarningCountIn(groupTitle), 4, groupRow); // Warnings
-			ExcelUtils.createCell(ValidationCollector.get().getErrorCountIn(groupTitle), 5, groupRow); // Errors
+			ExcelUtils.createCell(getCollector().getSummaryCountIn(groupTitle), 2, groupRow); // Summary
+			ExcelUtils.createCell(getCollector().getInformationCountIn(groupTitle), 3, groupRow); // Info
+			ExcelUtils.createCell(getCollector().getWarningCountIn(groupTitle), 4, groupRow); // Warnings
+			ExcelUtils.createCell(getCollector().getErrorCountIn(groupTitle), 5, groupRow); // Errors
 		}
 
 		return groupNameCells;
@@ -315,10 +315,10 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 		ExcelUtils.createCell("", 0, styles.get(StyleName.GROUP), totalsRow); // Status
 		ExcelUtils.createCell("Total", 1, styles.get(StyleName.RESULT_TITLE), totalsRow); // Title
-		ExcelUtils.createCell(ValidationCollector.get().getTotalSummaryCount(), 2, totalsRow); // Summary count
-		ExcelUtils.createCell(ValidationCollector.get().getTotalInformationCount(), 3, totalsRow); // Information count
-		ExcelUtils.createCell(ValidationCollector.get().getTotalWarningCount(), 4, totalsRow); // Warnings count
-		ExcelUtils.createCell(ValidationCollector.get().getTotalErrorCount(), 5, totalsRow); // Errors count
+		ExcelUtils.createCell(getCollector().getTotalSummaryCount(), 2, totalsRow); // Summary count
+		ExcelUtils.createCell(getCollector().getTotalInformationCount(), 3, totalsRow); // Information count
+		ExcelUtils.createCell(getCollector().getTotalWarningCount(), 4, totalsRow); // Warnings count
+		ExcelUtils.createCell(getCollector().getTotalErrorCount(), 5, totalsRow); // Errors count
 	}
 
 	/**
@@ -350,7 +350,7 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 
 		Map<String, TotalsPerResultCells> tableCells = new HashMap<>();
 
-		for (Map.Entry<String, List<ValidationResult>> group : ValidationCollector.get().getAllResults().entrySet()) {
+		for (Map.Entry<String, List<ValidationResult>> group : getCollector().getAllResults().entrySet()) {
 
 			String groupName = group.getKey();
 			List<ValidationResult> results = group.getValue();
@@ -467,7 +467,7 @@ public class ExcelReport<T extends Command<?> & ConfigurableReporting> extends R
 	 */
 	private void createDetailsSheet(Map<String, TotalsPerResultCells> totalsPerResultCellRefs) {
 
-		for (List<ValidationResult> results : ValidationCollector.get().getAllResults().values()) {
+		for (List<ValidationResult> results : getCollector().getAllResults().values()) {
 			for (ValidationResult result : results) {
 
 				Sheet resultSheet = workbook.createSheet(result.getId());

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/Report.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/Report.java
@@ -23,6 +23,7 @@ import java.util.Date;
 
 import com.documaster.validator.config.commands.Command;
 import com.documaster.validator.config.delegates.ConfigurableReporting;
+import com.documaster.validator.validation.collector.ValidationCollector;
 import org.apache.commons.lang.StringUtils;
 
 public abstract class Report<T extends Command<?> & ConfigurableReporting> {
@@ -31,15 +32,23 @@ public abstract class Report<T extends Command<?> & ConfigurableReporting> {
 
 	private String title;
 
-	Report(T config, String title) {
+	private ValidationCollector collector;
+
+	Report(T config, ValidationCollector collector, String title) {
 
 		this.config = config;
+		this.collector = collector;
 		this.title = title;
 	}
 
 	protected T getConfig() {
 
 		return config;
+	}
+
+	protected ValidationCollector getCollector() {
+
+		return collector;
 	}
 
 	protected String getTitle() {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportFactory.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/ReportFactory.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 import com.documaster.validator.config.commands.Command;
 import com.documaster.validator.config.delegates.ConfigurableReporting;
 import com.documaster.validator.exceptions.ReportingException;
+import com.documaster.validator.validation.collector.ValidationCollector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,8 @@ public class ReportFactory {
 		// Prevent instantiation
 	}
 
-	public static <T extends Command<?> & ConfigurableReporting> void generateReports(T config, String title) {
+	public static <T extends Command<?> & ConfigurableReporting> void generateReports(
+			T config, ValidationCollector collector, String title) {
 
 		EnumSet<ReportType> reportTypes = EnumSet.noneOf(ReportType.class);
 		reportTypes.addAll(config.getReportConfiguration().getOutputTypes());
@@ -46,10 +48,10 @@ public class ReportFactory {
 				switch (outputType) {
 					case EXCEL_XLS:
 					case EXCEL_XLSX:
-						new ExcelReport<>(config, outputType, title).generate();
+						new ExcelReport<>(config, outputType, collector, title).generate();
 						break;
 					case XML:
-						new XMLReport<>(config, title).generate();
+						new XMLReport<>(config, collector, title).generate();
 						break;
 					default:
 						throw new ReportingException("Unknown report type: " + outputType);

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/XMLReport.java
@@ -49,9 +49,9 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 
 	private XMLStreamWriter writer;
 
-	XMLReport(T config, String title) {
+	XMLReport(T config, ValidationCollector collector, String title) {
 
-		super(config, title);
+		super(config, collector, title);
 	}
 
 	@Override
@@ -132,13 +132,12 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 	private void writeValidationSummary() throws XMLStreamException {
 
 		start("summary");
-		attr("summary", ValidationCollector.get().getTotalSummaryCount());
-		attr("info", ValidationCollector.get().getTotalInformationCount());
-		attr("warn", ValidationCollector.get().getTotalWarningCount());
-		attr("error", ValidationCollector.get().getTotalErrorCount());
+		attr("summary", getCollector().getTotalSummaryCount());
+		attr("info", getCollector().getTotalInformationCount());
+		attr("warn", getCollector().getTotalWarningCount());
+		attr("error", getCollector().getTotalErrorCount());
 
-		for (Map.Entry<String, List<ValidationResult>> group : ValidationCollector.get()
-				.getAllResults().entrySet()) {
+		for (Map.Entry<String, List<ValidationResult>> group : getCollector().getAllResults().entrySet()) {
 
 			startGroup(group.getKey());
 
@@ -157,7 +156,7 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 
 		start("details");
 
-		for (Map.Entry<String, List<ValidationResult>> group : ValidationCollector.get().getAllResults().entrySet()) {
+		for (Map.Entry<String, List<ValidationResult>> group : getCollector().getAllResults().entrySet()) {
 
 			startGroup(group.getKey());
 
@@ -210,10 +209,10 @@ class XMLReport<T extends Command<?> & ConfigurableReporting> extends Report<T> 
 		start("group");
 
 		attr("name", groupName);
-		attr("summary", ValidationCollector.get().getSummaryCountIn(groupName));
-		attr("info", ValidationCollector.get().getInformationCountIn(groupName));
-		attr("warn", ValidationCollector.get().getWarningCountIn(groupName));
-		attr("error", ValidationCollector.get().getErrorCountIn(groupName));
+		attr("summary", getCollector().getSummaryCountIn(groupName));
+		attr("info", getCollector().getInformationCountIn(groupName));
+		attr("warn", getCollector().getWarningCountIn(groupName));
+		attr("error", getCollector().getErrorCountIn(groupName));
 	}
 
 	private void startTest(ValidationResult test) throws XMLStreamException {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/Validator.java
@@ -18,6 +18,8 @@
 package com.documaster.validator.validation;
 
 import com.documaster.validator.config.commands.Command;
+import com.documaster.validator.validation.collector.ValidationCollector;
+import com.documaster.validator.validation.collector.ValidationResult;
 
 /**
  * A base contract for all {@link Validator}s.
@@ -30,11 +32,14 @@ import com.documaster.validator.config.commands.Command;
  */
 public abstract class Validator<T extends Command> {
 
-	private T command;
+	private final T command;
 
-	public Validator(T command) {
+	private final ValidationCollector collector;
+
+	public Validator(T command, ValidationCollector collector) {
 
 		this.command = command;
+		this.collector = collector;
 	}
 
 	protected T getCommand() {
@@ -42,5 +47,15 @@ public abstract class Validator<T extends Command> {
 		return command;
 	}
 
-	public abstract void run() throws Exception;
+	public ValidationCollector getCollector() {
+
+		return collector;
+	}
+
+	protected void collect(ValidationResult result) {
+
+		collector.collect(result);
+	}
+
+	public abstract ValidationCollector run() throws Exception;
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationCollector.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/collector/ValidationCollector.java
@@ -17,14 +17,17 @@
  */
 package com.documaster.validator.validation.collector;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Collects information about the executed validation.
  */
 public class ValidationCollector {
-
-	private static ValidationCollector instance;
 
 	private Map<String, List<ValidationResult>> results;
 
@@ -40,7 +43,7 @@ public class ValidationCollector {
 
 	private Map<String, ValidationStatus> statuses;
 
-	private ValidationCollector() {
+	public ValidationCollector() {
 
 		results = new LinkedHashMap<>();
 
@@ -49,15 +52,6 @@ public class ValidationCollector {
 		warningCount = new HashMap<>();
 		errorCount = new HashMap<>();
 		statuses = new HashMap<>();
-	}
-
-	public static ValidationCollector get() {
-
-		if (instance == null) {
-			instance = new ValidationCollector();
-		}
-
-		return instance;
 	}
 
 	public Map<String, List<ValidationResult>> getAllResults() {
@@ -92,17 +86,17 @@ public class ValidationCollector {
 
 	public int getInformationCountIn(String groupName) {
 
-		return informationCount.containsKey(groupName) ? informationCount.get(groupName) : 0;
+		return informationCount.getOrDefault(groupName, 0);
 	}
 
 	public int getWarningCountIn(String groupName) {
 
-		return warningCount.containsKey(groupName) ? warningCount.get(groupName) : 0;
+		return warningCount.getOrDefault(groupName, 0);
 	}
 
 	public int getErrorCountIn(String groupName) {
 
-		return errorCount.containsKey(groupName) ? errorCount.get(groupName) : 0;
+		return errorCount.getOrDefault(groupName, 0);
 	}
 
 	public int getTotalResultCountIn(String groupName) {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/ValidationGroup.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/provider/ValidationGroup.java
@@ -67,8 +67,8 @@ public enum ValidationGroup {
 		return prefix;
 	}
 
-	public String getNextGroupId() {
+	public String getNextGroupId(ValidationCollector collector) {
 
-		return prefix + (ValidationCollector.get().getTotalResultCountIn(name) + 1);
+		return prefix + (collector.getTotalResultCountIn(name) + 1);
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XMLValidator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XMLValidator.java
@@ -35,12 +35,19 @@ public class XMLValidator {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(XMLValidator.class);
 
-	public static boolean isValid(Noark53PackageEntity entity, boolean ignoreNonComplianceToSchema) {
+	private ValidationCollector collector;
+
+	public XMLValidator(ValidationCollector collector) {
+
+		this.collector = collector;
+	}
+
+	public boolean isValid(Noark53PackageEntity entity, boolean ignoreNonComplianceToSchema) {
 
 		LOGGER.info("Validating XML File {} ...", entity.getXmlFile());
 
 		ValidationResult result = new ValidationResult(
-				ValidationGroup.PACKAGE.getNextGroupId(), entity.getXmlFileName() + " integrity",
+				ValidationGroup.PACKAGE.getNextGroupId(collector), entity.getXmlFileName() + " integrity",
 				"Tests whether the XML file 1) exists, 2) is valid XML, 3) complies with the Noark schemas, "
 						+ "and, optionally, 4) complies with the custom schemas",
 				ValidationGroup.PACKAGE.getName());
@@ -62,7 +69,7 @@ public class XMLValidator {
 					entity.getXmlFile(), result, entity.getCustomSchemas(), NoarkXMLHandler.Schema.CUSTOM, true);
 		}
 
-		ValidationCollector.get().collect(result);
+		collector.collect(result);
 
 		return exists && isWellFormed && (compliesWithNoarkSchemas || ignoreNonComplianceToSchema);
 	}
@@ -111,7 +118,8 @@ public class XMLValidator {
 			// Report a summary of the errors and warnings
 			List<BaseItem> summaryItems = handler.getSummaryOfExceptionsAsItems();
 			result.addSummaries(summaryItems);
-			result.addInformation(new BaseItem().add("Information",
+			result.addInformation(new BaseItem().add(
+					"Information",
 					String.format("Distinct errors in %s schema(s): %d", schemaType, summaryItems.size())));
 
 			return false;

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XSDValidator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/noark53/validators/XSDValidator.java
@@ -33,12 +33,19 @@ public class XSDValidator {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(XSDValidator.class);
 
-	public static boolean isValid(File xsdFile, String checksum) {
+	private ValidationCollector collector;
+
+	public XSDValidator(ValidationCollector collector) {
+
+		this.collector = collector;
+	}
+
+	public boolean isValid(File xsdFile, String checksum) {
 
 		LOGGER.info("Validating XSD File {} ...", xsdFile);
 
 		ValidationResult result = new ValidationResult(
-				ValidationGroup.PACKAGE.getNextGroupId(), xsdFile.getName() + " integrity",
+				ValidationGroup.PACKAGE.getNextGroupId(collector), xsdFile.getName() + " integrity",
 				"Tests whether the XSD schema 1) exists, 2) is valid XML, and 3) its checksum "
 						+ "matches the checksum of its Noark counterpart",
 				ValidationGroup.PACKAGE.getName());
@@ -47,7 +54,7 @@ public class XSDValidator {
 		boolean isWellFormed = validateIntegrity(xsdFile, result);
 		boolean checksumMatches = validateChecksum(xsdFile, result, checksum);
 
-		ValidationCollector.get().collect(result);
+		collector.collect(result);
 
 		return exists && isWellFormed && checksumMatches;
 	}


### PR DESCRIPTION
* Remove the log4j2 configuration from the classpath
* Add setters to the Noark53Command and its delegates

This PR does not depend on any other PRs, but it is recommended that it is reviewed and merged after PR #30, because a setter for `customSchemaLocation` will need to be added.

Closes #34.