### PR TITLE
Fix path-building logic for accessing a resource as stream

### DIFF
--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/Noark5Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/Noark5Validator.java
@@ -320,9 +320,7 @@ public abstract class Noark5Validator<T extends Noark5Command> extends Validator
 
 		LOGGER.info("Validating extraction ...");
 
-		String validationFileLocation = "noark5"
-						+ File.separator + getCommand().getName()
-						+ File.separator + getCommand().getName() + "-validation.xml";
+		String validationFileLocation = MessageFormat.format("noark5/{0}/{0}-validation.xml", getCommand().getName());
 
 		JAXBContext jaxbContext = JAXBContext
 				.newInstance(ValidationProvider.class, Data.class, ValidationData.class, ValidationGroup.class,


### PR DESCRIPTION
When using getResourceAsStream, we must not use the file separator.
"/" must be used instead.