### PR TITLE
Add support for large excel reports generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,26 @@ You can also change the persistence settings:
 ```
 java -jar noark-extraction-validator-0.4.0.jar <noark-version> -extraction /path/to/uttrekk/directory -output-dir /path/to/report/output/directory -db-name myDBName -storage hsqldb_server -server-location http://my.hsqldb.server.com
 ```
-*Do not modify* the persistence settings unless:
-* You would like to run several instances of the validator at the same time
-  * In this case, you need to modify the target database name to avoid conflicts (-db-name).
-* You would like to persist the database created by the validator
+If you would like to run several instances of the validator at the same time, you will have to use the *hsqldb_server* or *hsqldb_file* persistence settings and specify a different DB name / DB file location for each instance:
+* For *hsqldb_file* change the `-db-dir-location` argument
+* For *hsqldb_server* change the `-db-name` argument
+
+If you would like to persist the database created by the validator then it's best to use *hsqldb_server*:
   * In this case, you need to create a server instance of HSQLDB 1.8.0. Refer to [HSQLDB's page](http://hsqldb.org/) for more information and to [HSQLDB 1.8.0](https://sourceforge.net/projects/hsqldb/files/) for the binaries. Running the server would include:
     ```
     java -cp hsqldb.jar org.hsqldb.Server -database.0 file:mydb -dbname.0 xdb
     ```
     where **xdb** is the name of the default database.
+    
+In case of huge extractions you can also specify the storage type to be *hsqldb_file* like so:
+```
+java -jar noark-extraction-validator-0.4.0.jar <noark-version> -extraction /path/to/uttrekk/directory -output-dir /path/to/report/output/directory -storage hsqldb_file
+```
+Keep in mind that this will make the validation run slower (2 times or more), but could be the only option when having to deal with extremely large extractions and still generate an EXCEL_XLS report.
+Note that by default the database storage directory is called *"noark-extraction-validator-db"* and is situated in the OS temporary dir, but can be specified via the *-db-dir-location* flag:
+```
+java -jar noark-extraction-validator-0.4.0.jar <noark-version> -extraction /path/to/uttrekk/directory -output-dir /path/to/report/output/directory -storage hsqldb_file -db-dir-location /path/to/desired/db-storage/direcotry
+```
 
 Making the validation process less strict is also possible. The default behavior of the validator is to stop execution if an XML file does not comply with the corresponding Noark XSD schema. To continue execution instead:
 ```

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ReportConfiguration.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/ReportConfiguration.java
@@ -45,6 +45,11 @@ public class ReportConfiguration implements Delegate {
 			description = "The output type of the validation report. Possible values: XML, EXCEL_XLS, EXCEL_XLSX")
 	private List<ReportType> outputTypes = defaultReportTypes;
 
+	private static final String IN_MEMORY_XLSX_REPORT = "-in-memory-xlsx-report";
+	@Parameter(names = IN_MEMORY_XLSX_REPORT, description = "Generate the XLSX report using the older, more " +
+			"memory consuming fashion (can be used for backwards compatibility)", hidden = true)
+	private boolean inMemoryXlsxReport;
+
 	static {
 		defaultReportTypes = new ArrayList<>();
 		defaultReportTypes.add(EXCEL_XLSX);
@@ -68,6 +73,16 @@ public class ReportConfiguration implements Delegate {
 	public void setOutputTypes(List<ReportType> outputTypes) {
 
 		this.outputTypes = outputTypes;
+	}
+
+	public boolean isInMemoryXlsxReport() {
+
+		return inMemoryXlsxReport;
+	}
+
+	public void setInMemoryXlsxReport(boolean inMemoryXlsxReport) {
+
+		this.inMemoryXlsxReport = inMemoryXlsxReport;
 	}
 
 	@Override

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/StorageConfiguration.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/config/delegates/StorageConfiguration.java
@@ -32,6 +32,10 @@ public class StorageConfiguration implements Delegate {
 	@Parameter(names = DATABASE_NAME, description = "The name of the database")
 	private String databaseName = "xdb";
 
+	private static final String DATABASE_DIR_LOCATION = "-db-dir-location";
+	@Parameter(names = DATABASE_DIR_LOCATION, description = "The location of the dir where the database will be stored")
+	private String databaseDirLocation = System.getProperty("java.io.tmpdir") + "/noark-extraction-validator-db";
+
 	private static final String SERVER_LOCATION = "-server-location";
 	@Parameter(names = SERVER_LOCATION, description = "The server location")
 	private String serverLocation = "localhost";
@@ -54,6 +58,16 @@ public class StorageConfiguration implements Delegate {
 	public void setDatabaseName(String databaseName) {
 
 		this.databaseName = databaseName;
+	}
+
+	public String getDatabaseDirLocation() {
+
+		return databaseDirLocation;
+	}
+
+	public void setDatabaseDirLocation(String databaseDirLocation) {
+
+		this.databaseDirLocation = databaseDirLocation;
 	}
 
 	public String getServerLocation() {
@@ -79,6 +93,10 @@ public class StorageConfiguration implements Delegate {
 			case HSQLDB_SERVER:
 				if (serverLocation == null) {
 					throw new ParameterException(SERVER_LOCATION + " must be specified");
+				}
+			case HSQLDB_FILE:
+				if (databaseDirLocation == null) {
+					throw new ParameterException(DATABASE_DIR_LOCATION + " must be specified");
 				}
 			case HSQLDB_IN_MEMORY:
 				if (databaseName == null) {

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/reporting/excel/ExcelUtils.java
@@ -29,6 +29,7 @@ import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
 
 public class ExcelUtils {
 
@@ -102,8 +103,14 @@ public class ExcelUtils {
 
 	private static Hyperlink createHyperLinkTo(Cell cell) {
 
-		Hyperlink link = cell.getSheet().getWorkbook().getCreationHelper().createHyperlink(Hyperlink.LINK_DOCUMENT);
-		link.setAddress(MessageFormat.format("''{0}''!{1}", cell.getSheet().getSheetName(), cell.getAddress()));
+		return createHyperLinkTo(cell.getSheet(), MessageFormat.format(
+				"''{0}''!{1}", cell.getSheet().getSheetName(), cell.getAddress()));
+	}
+
+	public static Hyperlink createHyperLinkTo(Sheet sheet, String linkAddress) {
+
+		Hyperlink link = sheet.getWorkbook().getCreationHelper().createHyperlink(Hyperlink.LINK_DOCUMENT);
+		link.setAddress(linkAddress);
 
 		return link;
 	}
@@ -171,6 +178,10 @@ public class ExcelUtils {
 	public static void autoSizeColumns(Sheet sheet, int startCol, int endCol, Integer maxWidth) {
 
 		for (int i = startCol; i <= endCol; i++) {
+			if (sheet instanceof SXSSFSheet) {
+				// Columns need explicit tracking when using SXSSFSheet.class for 'streaming' report generation
+				((SXSSFSheet) sheet).trackColumnForAutoSizing(i);
+			}
 			sheet.autoSizeColumn(i);
 			if (maxWidth != null && maxWidth > 0 && sheet.getColumnWidth(i) > maxWidth) {
 				sheet.setColumnWidth(i, maxWidth);

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/Storage.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/Storage.java
@@ -161,6 +161,6 @@ public abstract class Storage {
 
 	public enum StorageType {
 
-		HSQLDB_IN_MEMORY, HSQLDB_SERVER
+		HSQLDB_IN_MEMORY, HSQLDB_FILE, HSQLDB_SERVER
 	}
 }

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/StorageFactory.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/storage/core/StorageFactory.java
@@ -48,6 +48,21 @@ public final class StorageFactory {
 
 				return persistence;
 
+			case HSQLDB_FILE:
+				DatabaseStorage filePersistence = new DatabaseStorage();
+				// Postgres syntax
+				// Allow column and table names beginning with underscore
+				filePersistence.setConnectionString(MessageFormat.format(
+						"jdbc:hsqldb:file:{0}/{1};hsqldb.write_delay=false;shutdown=true;sql.syntax_pgs=true;sql.regular_names=false;",
+						config.getDatabaseDirLocation(),
+						config.getDatabaseName()));
+				filePersistence.setDriver("org.hsqldb.jdbc.JDBCDriver");
+				filePersistence.setUsername("SA");
+				filePersistence.setPassword("");
+				filePersistence.setRole("dba");
+
+				return filePersistence;
+
 			case HSQLDB_SERVER:
 				DatabaseStorage serverPersistence = new DatabaseStorage();
 

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/storage/database/DatabaseStorage.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/storage/database/DatabaseStorage.java
@@ -32,7 +32,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Date;
-import java.util.Map;
 
 import com.documaster.validator.storage.core.Storage;
 import com.documaster.validator.storage.model.BaseItem;

--- a/noark-extraction-validator/src/main/java/com/documaster/validator/validation/Noark5Validator.java
+++ b/noark-extraction-validator/src/main/java/com/documaster/validator/validation/Noark5Validator.java
@@ -125,11 +125,17 @@ public abstract class Noark5Validator<T extends Noark5Command> extends Validator
 				FileUtils.deleteQuietly(structure.getNoarkSchemasDirectory());
 			}
 
-			ReportFactory.generateReports(getCommand(), getCollector(), getArchiveTitle());
+			try {
+				// The code below could throw an Error and the file database (if present) will not get deleted
+				ReportFactory.generateReports(getCommand(), getCollector(), getArchiveTitle());
 
-			if (Storage.get() != null) {
-				Storage.get().stopWriter();
-				Storage.get().destroy();
+				if (Storage.get() != null) {
+					Storage.get().stopWriter();
+					Storage.get().destroy();
+				}
+			} finally {
+
+				FileUtils.deleteQuietly(new File(getCommand().getStorageConfiguration().getDatabaseDirLocation()));
 			}
 		}
 


### PR DESCRIPTION
This is done using an SXSSFWorkbook which writes the contents
to the disk automatically once a certain threshold is reached.
The old XSSFWorkbook is replaced but can still be used with
the '-old-xlsx-report-generation' flag in case of any unforeseen
issues.

Also support for HSQL 'file' database is added which runs roughly
3 times slower than the 'in memory' one but can handle large
amounts of data. By default its contents are located in the OS
temp directory but can be explicitly specified.