### PR TITLE
Removed redundant settings from debian/rules.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,11 +16,3 @@
 
 %:
 	dh $@
-
-
-# dh_make generated override targets
-# This is example for Cmake (See https://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#       dh_auto_configure -- #  -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
-override_dh_auto_install:
-	dh_auto_install


### PR DESCRIPTION
This reduce the confusion when reading the build rules.